### PR TITLE
feat[api]: Added PATCH and DELETE routes for parties and candidates

### DIFF
--- a/__test__/db/testPopulation.js
+++ b/__test__/db/testPopulation.js
@@ -1,0 +1,15 @@
+import Party from '../../schemas/Party.js';
+import Constituency from '../../schemas/Constituency.js';
+import NominationDistrict from '../../schemas/NominationDistrict.js';
+import Candidate from '../../schemas/Candidate.js';
+import mockData from './mockData';
+import { districtsWithIds, candidateWithIds } from './addIds';
+
+export default async function populateDb() {
+	await Party.insertMany(mockData.parties);
+	await Constituency.insertMany(mockData.constituencies);
+	await NominationDistrict.insertMany(await districtsWithIds(mockData.nominationDistricts));
+	await Candidate.insertMany(await candidateWithIds(mockData.candidates));
+
+	return;
+}

--- a/__test__/db/testPopulation.js
+++ b/__test__/db/testPopulation.js
@@ -5,6 +5,9 @@ import Candidate from '../../schemas/Candidate.js';
 import mockData from './mockData';
 import { districtsWithIds, candidateWithIds } from './addIds';
 
+/**
+ * Populate the database with mock data
+ */
 export default async function populateDb() {
 	await Party.insertMany(mockData.parties);
 	await Constituency.insertMany(mockData.constituencies);

--- a/__test__/routes/candidateRoutes.test.js
+++ b/__test__/routes/candidateRoutes.test.js
@@ -127,7 +127,7 @@ describe('POST /api/v1/candidates', () => {
 describe('PATCH /api/v1/candidates/:id', () => {
 	let candidate, party, nominationDistrict;
 	beforeEach(async () => {
-		jest.clearAllMocks()
+		jest.clearAllMocks();
 		candidate = await Candidate.findOne();
 		party = await Party.findOne();
 		nominationDistrict = await NominationDistrict.findOne();

--- a/__test__/routes/electionRoutes.test.js
+++ b/__test__/routes/electionRoutes.test.js
@@ -3,13 +3,9 @@ import express from 'express';
 import mongoose from 'mongoose';
 import connectDb from '../setup/connect.js';
 import { jest } from '@jest/globals';
-import Party from '../../schemas/Party.js';
-import mockData from '../db/mockData.js';
 import axios from 'axios';
 import Candidate from '../../schemas/Candidate.js';
-import NominationDistrict from '../../schemas/NominationDistrict.js';
-import Constituency from '../../schemas/Constituency.js';
-import { districtsWithIds, candidateWithIds } from '../db/addIds.js';
+import populateDb from '../db/testPopulation.js';
 
 let router;
 const baseRoute = '/api/v1/parties';
@@ -22,10 +18,7 @@ const server = app.listen(0);
 
 beforeAll(async () => {
 	connectDb();
-	await Party.insertMany(mockData.parties);
-	await Constituency.insertMany(mockData.constituencies);
-	await NominationDistrict.insertMany(await districtsWithIds(mockData.nominationDistricts));
-	await Candidate.insertMany(await candidateWithIds(mockData.candidates));
+	await populateDb();
 	router = (await import('../../routes/electionRoutes.js')).default;
 });
 

--- a/__test__/routes/partyRoutes.test.js
+++ b/__test__/routes/partyRoutes.test.js
@@ -135,6 +135,110 @@ describe('POST /api/v1/parties', () => {
 	});
 });
 
+describe('PATCH /api/v1/parties/:id', () => {
+	let partyId;
+
+	beforeAll(async () => {
+			// Get a valid party ID from the mock data
+			const party = await Party.findOne();
+			partyId = party._id;
+	});
+
+	it('should return 200 OK when valid fields are provided', async () => {
+			const response = await request(app).patch(`${baseRoute}/${partyId}`).send({
+					name: 'Updated Party Name',
+			});
+			expect(response.statusCode).toBe(200);
+			expect(response.body.message).toBe('Party updated successfully');
+			expect(response.body.party).toMatchObject({
+					name: 'Updated Party Name',
+					...mongoDbFields,
+			});
+	});
+
+	it('should return 400 Bad Request when neither name nor list are provided', async () => {
+			const response = await request(app).patch(`${baseRoute}/${partyId}`).send({});
+			expect(response.statusCode).toBe(400);
+			expect(response.body.error).toBe('Please provide a name or list to update');
+	});
+
+	it('should return 400 Bad Request when invalid fields are present in the body', async () => {
+			const response = await request(app).patch(`${baseRoute}/${partyId}`).send({
+					name: 'Updated Party Name',
+					invalidField: 'invalid',
+			});
+			expect(response.statusCode).toBe(400);
+			expect(response.body.error).toBe('Invalid fields in the request body: invalidField');
+	});
+
+	it('should return 400 Bad Request when party ID format is invalid', async () => {
+			const response = await request(app).patch(`${baseRoute}/invalidId`).send({
+					name: 'Updated Party Name',
+			});
+			expect(response.statusCode).toBe(400);
+			expect(response.body.error).toBe('Invalid party ID format');
+	});
+
+	it('should return 404 Not Found when party is not found', async () => {
+			const nonExistentPartyId = new mongoose.Types.ObjectId(); // Generate a valid but non-existent ObjectId
+			const response = await request(app).patch(`${baseRoute}/${nonExistentPartyId}`).send({
+					name: 'Non-existent Party Name',
+			});
+			expect(response.statusCode).toBe(404);
+			expect(response.body.error).toBe('Party not found');
+	});
+
+	it('should return 400 Bad Request when name is shorter than 2 characters', async () => {
+			const response = await request(app).patch(`${baseRoute}/${partyId}`).send({
+					name: "a",
+			});
+			expect(response.statusCode).toBe(400);
+			expect(response.body.errors).toEqual({
+					name: 'Name must be longer than 2 characters.',
+			});
+	});
+
+	it('should return 400 Bad Request when name is longer than 100 characters', async () => {
+		const response = await request(app).patch(`${baseRoute}/${partyId}`).send({
+				name: "a".repeat(101),
+		});
+		expect(response.statusCode).toBe(400);
+		expect(response.body.errors).toEqual({
+				name: 'Name must be shorter than 100 characters.',
+		});
+	});
+
+	it('should return 400 Bad Request when list is more than one character', async () => {
+		const response = await request(app).patch(`${baseRoute}/${partyId}`).send({
+				list: "abc",
+		});
+		expect(response.statusCode).toBe(400);
+		expect(response.body.errors).toEqual({
+				list: 'List must be a one letter (uppercase) string.',
+		});
+	});
+
+	it('should return 400 Bad Request when list is not one uppercase letter', async () => {
+		const response = await request(app).patch(`${baseRoute}/${partyId}`).send({
+				list: "a",
+		});
+		expect(response.statusCode).toBe(400);
+		expect(response.body.errors).toEqual({
+				list: 'List must be a one letter (uppercase) string.',
+		});
+	});
+
+	it('should return 500 Internal Server Error when an unexpected error occurs', async () => {
+			jest.spyOn(Party, 'findByIdAndUpdate').mockRejectedValue(new Error('Unexpected error'));
+			jest.spyOn(console, 'error').mockImplementation(() => {}); // Silence error logging for this test
+			const response = await request(app).patch(`${baseRoute}/${partyId}`).send({
+					name: 'Updated Party Name',
+			});
+			expect(response.statusCode).toBe(500);
+			expect(response.body.error).toBe('An unexpected error occurred while updating the party');
+	});
+});
+
 afterAll(async () => {
 	server.close();
 	await Party.deleteMany();

--- a/__test__/routes/partyRoutes.test.js
+++ b/__test__/routes/partyRoutes.test.js
@@ -190,7 +190,7 @@ describe('PATCH /api/v1/parties/:id', () => {
 
 	it('should return 400 Bad Request when name is shorter than 2 characters', async () => {
 			const response = await request(app).patch(`${baseRoute}/${partyId}`).send({
-					name: "a",
+					name: 'a',
 			});
 			expect(response.statusCode).toBe(400);
 			expect(response.body.errors).toEqual({
@@ -200,7 +200,7 @@ describe('PATCH /api/v1/parties/:id', () => {
 
 	it('should return 400 Bad Request when name is longer than 100 characters', async () => {
 		const response = await request(app).patch(`${baseRoute}/${partyId}`).send({
-				name: "a".repeat(101),
+				name: 'a'.repeat(101),
 		});
 		expect(response.statusCode).toBe(400);
 		expect(response.body.errors).toEqual({
@@ -210,7 +210,7 @@ describe('PATCH /api/v1/parties/:id', () => {
 
 	it('should return 400 Bad Request when list is more than one character', async () => {
 		const response = await request(app).patch(`${baseRoute}/${partyId}`).send({
-				list: "abc",
+				list: 'abc',
 		});
 		expect(response.statusCode).toBe(400);
 		expect(response.body.errors).toEqual({
@@ -220,7 +220,7 @@ describe('PATCH /api/v1/parties/:id', () => {
 
 	it('should return 400 Bad Request when list is not one uppercase letter', async () => {
 		const response = await request(app).patch(`${baseRoute}/${partyId}`).send({
-				list: "a",
+				list: 'a',
 		});
 		expect(response.statusCode).toBe(400);
 		expect(response.body.errors).toEqual({

--- a/__test__/routes/partyRoutes.test.js
+++ b/__test__/routes/partyRoutes.test.js
@@ -280,8 +280,8 @@ describe('DELETE /api/v1/parties/:id', () => {
 			jest.spyOn(Party, 'findByIdAndDelete').mockRejectedValue(new Error('Unexpected error'));
 			jest.spyOn(console, 'error').mockImplementation(() => {}); // Silence error logging for this test
 			const response = await request(app).delete(`${baseRoute}/${partyId}`);
-			expect(response.statusCode).toBe(500);
 			expect(response.body.error).toBe('An unexpected error occurred while deleting the party');
+			expect(response.statusCode).toBe(500);
 	});
 });
 

--- a/__test__/utils/validationError.test.js
+++ b/__test__/utils/validationError.test.js
@@ -1,6 +1,6 @@
 // Make tests for the validationError function in utils/validationError.js
 
-import validationError, { checkIdsAndGiveErrors } from '../../utils/validationError.js';
+import validationError, { checkIdsAndGiveErrors, validateSingleObjectId } from '../../utils/validationError.js';
 
 describe('validationError', () => {
 	it('should return an object with relevant errors based on mongoose error (1)', () => {
@@ -131,5 +131,49 @@ describe('checkIdsAndGiveErrors', () => {
 		];
 		const result = checkIdsAndGiveErrors(idList);
 		expect(result).toEqual({});
+	});
+});
+
+describe('validateSingleObjectId', () => {
+	it('should return true if the ObjectId is valid', () => {
+		const id = '507f1f77bcf86cd799439011';
+		const result = validateSingleObjectId(id);
+		expect(result).toBe(true);
+	});
+
+	it('should return false if the ObjectId is invalid', () => {
+		const id = 'invalid';
+		const result = validateSingleObjectId(id);
+		expect(result).toBe(false);
+	});
+
+	it('should return false if the ObjectId is invalid (2)', () => {
+		const id = '507f1f77bcf86cd7994390111';
+		const result = validateSingleObjectId(id);
+		expect(result).toBe(false);
+	});
+
+	it('should return false if the ObjectId is invalid (3)', () => {
+		const id = '507f1f77bcf86cd79943901';
+		const result = validateSingleObjectId(id);
+		expect(result).toBe(false);
+	});
+
+	it('should return false if the ObjectId is invalid (4)', () => {
+		const id = 412894278;
+		const result = validateSingleObjectId(id);
+		expect(result).toBe(false);
+	});
+
+	it('should return false if the ObjectId is invalid (5)', () => {
+		const id = null;
+		const result = validateSingleObjectId(id);
+		expect(result).toBe(false);
+	});
+
+	it('should return false if the ObjectId is invalid (6)', () => {
+		const id = 853023948512;
+		const result = validateSingleObjectId(id);
+		expect(result).toBe(false);
 	});
 });

--- a/__test__/utils/validationError.test.js
+++ b/__test__/utils/validationError.test.js
@@ -1,0 +1,135 @@
+// Make tests for the validationError function in utils/validationError.js
+
+import validationError, { checkIdsAndGiveErrors } from '../../utils/validationError.js';
+
+describe('validationError', () => {
+	it('should return an object with relevant errors based on mongoose error (1)', () => {
+		const error = {
+			errors: {
+				name: {
+					message: 'Name is required',
+					name: 'ValidatorError',
+					properties: {
+						message: 'Name is required',
+						type: 'required',
+					},
+					kind: 'required',
+				},
+			}
+		};
+		const result = validationError(error);
+		expect(result).toEqual({ name: 'name is required' });
+
+	});
+
+	it('should return an object with relevant errors based on mongoose error (2)', () => {
+		const error = {
+			errors: {
+				name: {
+					message: 'Name must be longer than 2 characters',
+					name: 'ValidatorError',
+					properties: {
+						message: 'Name must be longer than 2 characters',
+						type: 'user defined',
+					},
+					kind: 'user defined',
+				},
+				list: {
+					message: 'List must be a one letter (uppercase) string',
+					name: 'ValidatorError',
+					properties: {
+						message: 'List must be a one letter (uppercase) string',
+						type: 'user defined',
+					},
+					kind: 'user defined',
+				}
+			}
+		};
+		const result = validationError(error);
+		expect(result).toEqual({
+			name: 'Name must be longer than 2 characters',
+			list: 'List must be a one letter (uppercase) string',
+		});
+	});
+
+	it('should return an object with relevant errors based on mongoose error (3)', () => {
+		const error = {
+			errors: {
+				name: {
+					message: 'Name is required',
+					name: 'ValidatorError',
+					properties: {
+						message: 'Name is required',
+						type: 'required',
+					},
+					kind: 'required',
+				},
+				party: {
+					value: 5,
+					valueType: 'number',
+					kind: 'ObjectId',
+				},
+			}
+		};
+		const result = validationError(error);
+		expect(result).toEqual({
+			name: 'name is required',
+			party: '\'5\' (type number) is not a valid ObjectId',
+		});
+	});
+});
+
+describe('checkIdsAndGiveErrors', () => {
+	it('should return an object with relevant errors based on ObjectIds validity', () => {
+		const idList = [
+			{ id: '5', name: 'party' },
+			{ id: 'invalid', name: 'nominationDistrict' },
+		];
+		const result = checkIdsAndGiveErrors(idList);
+		expect(result).toEqual({
+			party: '\'5\' (type string) is not a valid ObjectId',
+			nominationDistrict: '\'invalid\' (type string) is not a valid ObjectId',
+		});
+	});
+
+	it('should return an object with relevant errors based on ObjectIds validity (2)', () => {
+		const idList = [
+			{ id: null, name: 'party' },
+			{ id: 'invalid', name: 'nominationDistrict' },
+		];
+		const result = checkIdsAndGiveErrors(idList);
+		expect(result).toEqual({
+			party: '\'null\' (type object) is not a valid ObjectId',
+			nominationDistrict: '\'invalid\' (type string) is not a valid ObjectId',
+		});
+	});
+
+	it('should return an object with relevant errors based on ObjectIds validity (3)', () => {
+		const idList = [
+			{ id: '507fbc292b83c83cf284de21', name: 'party' },
+			{ id: 392154, name: 'nominationDistrict' },
+		];
+		const result = checkIdsAndGiveErrors(idList);
+		expect(result).toEqual({
+			nominationDistrict: '\'392154\' (type number) is not a valid ObjectId',
+		});
+	});
+
+	it('should return an empty object if no ObjectIds are provided', () => {
+		const idList = [
+			{ name: 'party' },
+			{ name: 'nominationDistrict' },
+		];
+		const result = checkIdsAndGiveErrors(idList);
+		expect(result).toEqual({});
+	});
+
+	it('should return an empty object if all ObjectIds are valid', () => {
+		const idList = [
+			{ id: '507fbc292b83c83cf284de21', name: 'party' },
+			{ id: '507f1f77bcf86cd799439011', name: 'nominationDistrict' },
+		];
+		const result = checkIdsAndGiveErrors(idList);
+		expect(result).toEqual({});
+	});
+});

--- a/controllers/candidate.js
+++ b/controllers/candidate.js
@@ -37,13 +37,17 @@ async function addCandidate(req, res) {
   }
 }
 
+/**
+ * Update a candidate in the database by ID
+ * @param {Request} req Request object containing the candidate object in the body and the candidate ID in the params
+ * @param {Response} res Express response object to send the response
+ * @returns {Response} Success or error message
+ */
 async function updateCandidate(req, res) {
   const { id } = req.params;
   const candidate = req.body;
 
   const idErrs = checkIdsAndGiveErrors([{ name: 'party', id: candidate.party }, { name: 'nominationDistrict', id: candidate.nominationDistrict }]);
-
-  console.log(idErrs);
 
   if (Object.keys(idErrs).length > 0) {
     return res.status(400).json({

--- a/controllers/candidate.js
+++ b/controllers/candidate.js
@@ -1,5 +1,5 @@
 import Candidate from '../schemas/Candidate.js';
-import validationError, { checkIdsAndGiveErrors } from '../utils/validationError.js';
+import validationError, { checkIdsAndGiveErrors, validateSingleObjectId } from '../utils/validationError.js';
 
 /**
  * Add a candidate to the database
@@ -83,7 +83,37 @@ async function updateCandidate(req, res) {
   }
 }
 
-export { addCandidate, updateCandidate };
+async function deleteCandidate(req, res) {
+  const { id } = req.params;
+
+
+  try {
+    const deletedCandidate = await Candidate.findByIdAndDelete(id);
+
+    if (!deletedCandidate) {
+      return res.status(204).send();
+    }
+
+    return res.status(200).json({
+      message: 'Candidate deleted successfully',
+      candidate: deletedCandidate,
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    if (error.name === 'CastError') {
+      return res.status(400).json({
+        error: '\'' + id + '\' (type ' + typeof id + ') is not a valid ObjectId',
+      });
+    }
+
+    console.error(`Error deleting candidate: ${error.message}`);
+    return res.status(500).json({
+      error: 'An unexpected error occurred while deleting candidate',
+    });
+  }
+}
+
+export { addCandidate, updateCandidate, deleteCandidate };
 
 /**
  * @import { Request, Response } from 'express';

--- a/controllers/candidate.js
+++ b/controllers/candidate.js
@@ -1,5 +1,5 @@
 import Candidate from '../schemas/Candidate.js';
-import validationError, { checkIdsAndGiveErrors, validateSingleObjectId } from '../utils/validationError.js';
+import validationError, { checkIdsAndGiveErrors } from '../utils/validationError.js';
 
 /**
  * Add a candidate to the database
@@ -83,6 +83,12 @@ async function updateCandidate(req, res) {
   }
 }
 
+/**
+ * Delete a candidate from the database by ID.
+ * @param {Request} req - Express request object containing the candidate ID in the URL parameters.
+ * @param {Response} res - Express response object to send the response.
+ * @returns {Response} - A success message and deleted candidate data, or an error message.
+ */
 async function deleteCandidate(req, res) {
   const { id } = req.params;
 
@@ -99,13 +105,13 @@ async function deleteCandidate(req, res) {
       candidate: deletedCandidate,
     });
   } catch (error) {
-    // eslint-disable-next-line no-console
     if (error.name === 'CastError') {
       return res.status(400).json({
         error: '\'' + id + '\' (type ' + typeof id + ') is not a valid ObjectId',
       });
     }
-
+    
+    // eslint-disable-next-line no-console
     console.error(`Error deleting candidate: ${error.message}`);
     return res.status(500).json({
       error: 'An unexpected error occurred while deleting candidate',

--- a/controllers/party.js
+++ b/controllers/party.js
@@ -97,9 +97,7 @@ async function deleteParty(req, res) {
 			const deletedParty = await Party.findByIdAndDelete(partyId);
 
 			if (!deletedParty) {
-					return res.status(204).json({
-							error: 'Party not found',
-					});
+					return res.status(204).json();
 			}
 
 			return res.status(200).json({

--- a/controllers/party.js
+++ b/controllers/party.js
@@ -77,7 +77,46 @@ async function updateParty(req, res) {
 }
 
 /**
- * Validate the update request for a party
+ * Delete a party from the database
+ * @param {Request} req Request object containing the party ID in the params
+ * @param {Response} res Express response object to send the response
+ * @returns {Response} Success or error message
+ */
+async function deleteParty(req, res) {
+	const partyId = req.params.id;
+
+	// Validate the partyId
+	if (!validateSingleObjectId(partyId)) {
+			return res.status(400).json({
+					error: 'Invalid party ID format',
+			});
+	}
+
+	try {
+			// Find the party by ID and remove it
+			const deletedParty = await Party.findByIdAndDelete(partyId);
+
+			if (!deletedParty) {
+					return res.status(204).json({
+							error: 'Party not found',
+					});
+			}
+
+			return res.status(200).json({
+					message: 'Party deleted successfully',
+					party: deletedParty,
+			});
+	} catch (error) {
+			// eslint-disable-next-line no-console
+			console.error(`Error deleting party: ${error.message}`);
+			return res.status(500).json({
+					error: 'An unexpected error occurred while deleting the party',
+			});
+	}
+}
+
+/**
+ * Validate the request for a party with an id in the params
  * @param {string} partyId The ID of the party
  * @param {object} updatedPartyData The update data
  * @returns {object|null} Error object if validation fails, or null if valid
@@ -108,7 +147,7 @@ function validateUpdateRequest(partyId, updatedPartyData) {
 	return null;
 }
 
-export { addParty, updateParty };
+export { addParty, updateParty, deleteParty };
 
 /**
  * @import { Request, Response } from 'express';

--- a/controllers/party.js
+++ b/controllers/party.js
@@ -31,7 +31,45 @@ async function addParty(req, res) {
 	}
 }
 
-export { addParty };
+/**
+ * Update a party in the database
+ * @param {Request} req Request object containing the party object in the body and the party ID in the params
+ * @param {Response} res Express response object to send the response
+ * @returns {Response} Success or error message
+ */
+async function updateParty(req, res) {
+	const partyId = req.params.id;
+	const updatedPartyData = req.body;
+
+	try {
+			// Find the party by ID and update it
+			const updatedParty = await Party.findByIdAndUpdate(partyId, updatedPartyData, { new: true, runValidators: true });
+
+			if (!updatedParty) {
+					return res.status(404).json({
+							error: 'Party not found',
+					});
+			}
+
+			return res.status(200).json({
+					message: 'Party updated successfully',
+					party: updatedParty,
+			});
+	} catch (error) {
+			if (error.name === 'ValidationError') {
+					return res.status(400).json({
+							errors: validationError(error),
+					});
+			}
+			// eslint-disable-next-line no-console
+			console.error(`Error updating party: ${error.message}`);
+			return res.status(500).json({
+					error: 'An unexpected error occurred while updating the party',
+			});
+	}
+}
+
+export { addParty, updateParty };
 
 /**
  * @import { Request, Response } from 'express';

--- a/middleware/verifyToken.js
+++ b/middleware/verifyToken.js
@@ -14,7 +14,6 @@ const key = process.env.JWT_KEY;
  */
 export function auth(req, res, next) {
   const token = req.headers['authorization'];
-  console.log("token", token);
 
   if (!token) {
     return res.status(401).json({ message: 'No token provided' });

--- a/middleware/verifyToken.js
+++ b/middleware/verifyToken.js
@@ -14,6 +14,7 @@ const key = process.env.JWT_KEY;
  */
 export function auth(req, res, next) {
   const token = req.headers['authorization'];
+  console.log("token", token);
 
   if (!token) {
     return res.status(401).json({ message: 'No token provided' });

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
             },
             "devDependencies": {
                 "@eslint/js": "^9.11.1",
+                "cross-env": "^7.0.3",
                 "eslint": "^9.11.1",
                 "eslint-plugin-jest": "^28.8.3",
                 "eslint-plugin-jsdoc": "^50.4.3",
@@ -2573,6 +2574,24 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/cross-env": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.1"
+            },
+            "bin": {
+                "cross-env": "src/bin/cross-env.js",
+                "cross-env-shell": "src/bin/cross-env-shell.js"
+            },
+            "engines": {
+                "node": ">=10.14",
+                "npm": ">=6",
+                "yarn": ">=1"
             }
         },
         "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "dev:server": "nodemon index.js",
         "dev:lint": "nodemon --watch src --exec \"npx eslint .\"",
         "lint": "eslint .",
-        "test": "NODE_OPTIONS='--experimental-vm-modules' jest --runInBand",
+        "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --runInBand",
         "test2": "jest"
     },
     "repository": {
@@ -37,6 +37,7 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.11.1",
+        "cross-env": "^7.0.3",
         "eslint": "^9.11.1",
         "eslint-plugin-jest": "^28.8.3",
         "eslint-plugin-jsdoc": "^50.4.3",

--- a/routes/candidateRoutes.js
+++ b/routes/candidateRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { addCandidate, updateCandidate } from '../controllers/candidate.js';
+import { addCandidate, updateCandidate, deleteCandidate } from '../controllers/candidate.js';
 import { auth } from '../middleware/verifyToken.js';
 
 const router = express.Router();
@@ -11,6 +11,10 @@ router.post('/', auth, (req, res) => {
 
 router.patch('/:id', auth, (req, res) => {
   updateCandidate(req, res);
+});
+
+router.delete('/:id', auth, (req, res) => {
+  deleteCandidate(req, res);
 });
 
 export default router;

--- a/routes/candidateRoutes.js
+++ b/routes/candidateRoutes.js
@@ -1,25 +1,16 @@
 import express from 'express';
-import { addCandidate } from '../controllers/candidate.js';
+import { addCandidate, updateCandidate } from '../controllers/candidate.js';
 import { auth } from '../middleware/verifyToken.js';
 
 const router = express.Router();
 
 // Route for adding a candidate to the database
 router.post('/', auth, (req, res) => {
-    addCandidate(req, res);
+  addCandidate(req, res);
 });
 
-/*router.patch('/:id', auth, (req, res) => {
-  const id = req.params.id;
-  if (!id) {
-    return res.status(400).json({ error: 'Missing candidate ID' });
-  }
-
-  try {
-    updateCandidate(id, res);
-  } catch {
-    return res.status(500).json({ error: 'Internal server error' });
-  }
-});*/
+router.patch('/:id', auth, (req, res) => {
+  updateCandidate(req, res);
+});
 
 export default router;

--- a/routes/partyRoutes.js
+++ b/routes/partyRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { addParty } from '../controllers/party.js';
+import { addParty, updateParty  } from '../controllers/party.js';
 import { auth } from '../middleware/verifyToken.js';
 
 const router = express.Router();
@@ -7,6 +7,11 @@ const router = express.Router();
 // Route for adding a party to the database
 router.post('/', auth, (req, res) => {
 	addParty(req, res);
+});
+
+// Route for editing a party in the database
+router.patch('/:id', auth, (req, res) => {
+	updateParty(req, res);
 });
 
 export default router;

--- a/routes/partyRoutes.js
+++ b/routes/partyRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { addParty, updateParty  } from '../controllers/party.js';
+import { addParty, updateParty, deleteParty } from '../controllers/party.js';
 import { auth } from '../middleware/verifyToken.js';
 
 const router = express.Router();
@@ -12,6 +12,11 @@ router.post('/', auth, (req, res) => {
 // Route for editing a party in the database
 router.patch('/:id', auth, (req, res) => {
 	updateParty(req, res);
+});
+
+// Route for deleting a party from the database
+router.delete('/:id', auth, (req, res) => {
+	deleteParty(req, res);
 });
 
 export default router;

--- a/utils/validationError.js
+++ b/utils/validationError.js
@@ -32,7 +32,7 @@ function checkIdsAndGiveErrors(idList) {
 		}
 		if (!mongoose.Types.ObjectId.isValid(obj.id)) {
 			errorList[obj.name] = `'${obj.id}' (type ${typeof obj.id}) is not a valid ObjectId`;
-		};
+		}
 	}
 
 	return errorList;

--- a/utils/validationError.js
+++ b/utils/validationError.js
@@ -1,3 +1,5 @@
+import mongoose from 'mongoose';
+
 /**
  * Formats a mongoose validation error into a more readable format
  * @param {ValidationError} error The validation error object from mongoose
@@ -21,6 +23,22 @@ export default function validationError(error) {
 
 	return errorList;
 }
+
+function checkIdsAndGiveErrors(idList) {
+	let errorList = {};
+	for (const obj of idList) {
+		if (obj.id === undefined) {
+			continue;
+		}
+		if (!mongoose.Types.ObjectId.isValid(obj.id)) {
+			errorList[obj.name] = `'${obj.id}' (type ${typeof obj.id}) is not a valid ObjectId`;
+		};
+	}
+
+	return errorList;
+}
+
+export { checkIdsAndGiveErrors };
 
 /**
  * @typedef {import('mongoose').Error.ValidationError} ValidationError

--- a/utils/validationError.js
+++ b/utils/validationError.js
@@ -24,13 +24,30 @@ export default function validationError(error) {
 	return errorList;
 }
 
+/**
+ * Validates a single ObjectId
+ * @param {string} id - The MongoDB ObjectId to validate
+ * @returns {boolean} - Returns true if the ObjectId is valid, otherwise false
+ */
+function validateSingleObjectId(id) {
+	if (!mongoose.Types.ObjectId.isValid(id)) {
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Validates a list of ObjectIds and returns a list of errors if any invalid
+ * @param {Array<{id: string, name: string}>} idList - List of objects containing ObjectId and field names
+ * @returns {{[key: string]: string}} - A list of errors with the field name as the key and the error message as the value
+ */
 function checkIdsAndGiveErrors(idList) {
 	let errorList = {};
 	for (const obj of idList) {
 		if (obj.id === undefined) {
 			continue;
 		}
-		if (!mongoose.Types.ObjectId.isValid(obj.id)) {
+		if (!validateSingleObjectId(obj.id)) {
 			errorList[obj.name] = `'${obj.id}' (type ${typeof obj.id}) is not a valid ObjectId`;
 		}
 	}
@@ -38,8 +55,4 @@ function checkIdsAndGiveErrors(idList) {
 	return errorList;
 }
 
-export { checkIdsAndGiveErrors };
-
-/**
- * @typedef {import('mongoose').Error.ValidationError} ValidationError
- */
+export { validateSingleObjectId, checkIdsAndGiveErrors };

--- a/utils/validationError.js
+++ b/utils/validationError.js
@@ -2,7 +2,7 @@ import mongoose from 'mongoose';
 
 /**
  * Formats a mongoose validation error into a more readable format
- * @param {ValidationError} error The validation error object from mongoose
+ * @param {Error.ValidationError} error The validation error object from mongoose
  * @returns {{[key: string]: string}} A list of errors with the field name as the key and the error message as the value
  */
 export default function validationError(error) {
@@ -33,6 +33,10 @@ function validateSingleObjectId(id) {
 	if (!mongoose.Types.ObjectId.isValid(id)) {
 		return false;
 	}
+
+	if (new mongoose.Types.ObjectId(id).toString() !== id) {
+		return false;
+	}
 	return true;
 }
 
@@ -56,3 +60,7 @@ function checkIdsAndGiveErrors(idList) {
 }
 
 export { validateSingleObjectId, checkIdsAndGiveErrors };
+
+/**
+ * @import { Error } from 'mongoose'
+ */


### PR DESCRIPTION
## Decription
The changes include a PATCH and DELETE route for both candidates and parties for updating or deleting them. The routes require the id of the candidate or party to be deleted.

## Changes made
- Added PATCH '/candidates' which takes an id as param and fields to update in the body
- Added DELETE '/candidates' which takes an id as param
- Added PATCH '/parties' which takes an id as param and fields to update in the body
- Added DELETE '/parties' which takes an id as param

Resolves issues #6 and #7 

## Notes
- Should the DELETE route for party return 409 if the party still has candidates?