### PR TITLE
feat: CRUD functionalities for parties, candidates, constituencies, polling stations, and nomination districts

### DIFF
--- a/__test__/db/testPopulation.js
+++ b/__test__/db/testPopulation.js
@@ -2,8 +2,9 @@ import Party from '../../schemas/Party.js';
 import Constituency from '../../schemas/Constituency.js';
 import NominationDistrict from '../../schemas/NominationDistrict.js';
 import Candidate from '../../schemas/Candidate.js';
+import PollingStation from '../../schemas/PollingStation.js';
 import mockData from './mockData';
-import { districtsWithIds, candidateWithIds } from './addIds';
+import { districtsWithIds, candidateWithIds, pollingStationWithIds } from './addIds';
 
 /**
  * Populate the database with mock data
@@ -13,10 +14,12 @@ export default async function populateDb() {
 	await Constituency.deleteMany({});
 	await NominationDistrict.deleteMany({});
 	await Candidate.deleteMany({});
+	await PollingStation.deleteMany({});
 	await Party.insertMany(mockData.parties);
 	await Constituency.insertMany(mockData.constituencies);
 	await NominationDistrict.insertMany(await districtsWithIds(mockData.nominationDistricts));
 	await Candidate.insertMany(await candidateWithIds(mockData.candidates));
+	await PollingStation.insertMany(await pollingStationWithIds(mockData.pollingStations));
 
 	return;
 }

--- a/__test__/db/testPopulation.js
+++ b/__test__/db/testPopulation.js
@@ -9,6 +9,10 @@ import { districtsWithIds, candidateWithIds } from './addIds';
  * Populate the database with mock data
  */
 export default async function populateDb() {
+	await Party.deleteMany({});
+	await Constituency.deleteMany({});
+	await NominationDistrict.deleteMany({});
+	await Candidate.deleteMany({});
 	await Party.insertMany(mockData.parties);
 	await Constituency.insertMany(mockData.constituencies);
 	await NominationDistrict.insertMany(await districtsWithIds(mockData.nominationDistricts));

--- a/__test__/routes/candidateRoutes.test.js
+++ b/__test__/routes/candidateRoutes.test.js
@@ -71,6 +71,12 @@ describe('GET /api/v1/candidates', () => {
 		});
 	});
 
+	it('should return 200 OK and an empty list when no candidates match the query', async () => {
+		const response = await request(app).get(baseRoute + '?party=123456789012');
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toHaveLength(0);
+	});
+
 	it('should return 400 Bad Request when an invalid query is given', async () => {
 		const response = await request(app).get(baseRoute + '?invalidQuery=invalid');
 		expect(response.statusCode).toBe(400);

--- a/__test__/routes/candidateRoutes.test.js
+++ b/__test__/routes/candidateRoutes.test.js
@@ -49,7 +49,7 @@ describe('GET /api/v1/candidates', () => {
 				__v: expect.any(Number),
 			});
 		});
-	})
+	});
 
 	it('should return 200 OK and a filtered list of candidates when valid query is given', async () => {
 		const partyId = await Party.findOne().then(party => party._id);

--- a/__test__/routes/candidateRoutes.test.js
+++ b/__test__/routes/candidateRoutes.test.js
@@ -55,7 +55,6 @@ describe('GET /api/v1/candidates', () => {
 		const partyId = await Party.findOne().then(party => party._id);
 		const candidateCount = await Candidate.find({ party: partyId }).countDocuments();
 		const response = await request(app).get(baseRoute + '?party=' + partyId);
-		console.log(response.body);
 		expect(response.statusCode).toBe(200);
 		expect(response.body).toHaveLength(candidateCount);
 		response.body.forEach(candidate => {
@@ -72,7 +71,7 @@ describe('GET /api/v1/candidates', () => {
 	});
 
 	it('should return 200 OK and an empty list when no candidates match the query', async () => {
-		const response = await request(app).get(baseRoute + '?party=123456789012');
+		const response = await request(app).get(baseRoute + '?party=123456789012384920349123');
 		expect(response.statusCode).toBe(200);
 		expect(response.body).toHaveLength(0);
 	});
@@ -355,6 +354,7 @@ describe('DELETE /api/v1/candidates/:id', () => {
 });
 
 afterAll(async () => {
+	await mongoose.connection.db.dropDatabase();
 	await mongoose.connection.close();
 	server.close();
 });

--- a/__test__/routes/constituencyRoutes.test.js
+++ b/__test__/routes/constituencyRoutes.test.js
@@ -1,0 +1,203 @@
+import request from 'supertest';
+import express from 'express';
+import mongoose from 'mongoose';
+import connectDb from '../setup/connect.js';
+import { jest } from '@jest/globals';
+import populateDb from '../db/testPopulation.js';
+import mockData from '../db/mockData.js';
+import Constituency from '../../schemas/Constituency.js';
+
+let router;
+const baseRoute = '/api/v1/constituency';
+
+const app = express();
+app.use(express.json());
+app.use(baseRoute, async (req, res, next) => (await router)(req, res, next));
+
+const server = app.listen(0);
+
+beforeAll(async () => {
+	connectDb();
+	router = (await import('../../routes/constituencyRoutes.js')).default;
+
+	await populateDb();
+});
+
+jest.unstable_mockModule('../../middleware/verifyToken.js', () => {
+	return {
+		auth: jest.fn((req, res, next) => next()),
+	};
+});
+
+const mockError = (method) => {
+	jest.spyOn(mongoose.Model, method).mockRejectedValue(new Error('Unexpected error'));
+	jest.spyOn(console, 'error').mockImplementation(() => { });
+};
+
+describe('GET /api/v1/constituency', () => {
+	it('should return 200 OK and all constituencies when no query is given', async () => {
+		const response = await request(app).get(baseRoute);
+		expect(response.status).toBe(200);
+		expect(response.body).toHaveLength(mockData.constituencies.length);
+		response.body.forEach((constituency) => {
+			expect(constituency).toMatchObject({
+				_id: expect.any(String),
+				name: expect.any(String),
+			});
+		});
+	});
+
+	it('should return 200 OK and a list of constituencies that match the query', async () => {
+		const constituency = mockData.constituencies[0];
+		const response = await request(app).get(baseRoute).query({ name: constituency.name });
+		expect(response.status).toBe(200);
+		expect(response.body).toHaveLength(1);
+		expect(response.body[0]).toMatchObject({
+			_id: expect.any(String),
+			name: constituency.name,
+		});
+	});
+
+	it('should return 200 OK and an empty list when no constituencies match the query', async () => {
+		const response = await request(app).get(baseRoute).query({ name: 'invalid' });
+		expect(response.status).toBe(200);
+		expect(response.body).toHaveLength(0);
+	});
+
+	it('should return 400 Bad Request when an invalid query is given', async () => {
+		const response = await request(app).get(baseRoute + '?invalidQuery=invalid');
+		expect(response.statusCode).toBe(400);
+		expect(response.body.error).toBe('Invalid query parameter: invalidQuery');
+	});
+
+	it('should return 400 Bad Request when an invalid ID is given in the query', async () => {
+		const response = await request(app).get(baseRoute + '?_id=invalidId');
+		expect(response.statusCode).toBe(400);
+		expect(response.body.error).toBe('Invalid ID: invalidId');
+	});
+
+	it('should return 500 Internal Server Error when an unexpected error occurs', async () => {
+		jest.spyOn(mongoose.Model, 'find').mockRejectedValue(new Error('Unexpected error'));
+		jest.spyOn(console, 'error').mockImplementation(() => { });
+		const res = await request(app).get(baseRoute);
+		expect(res.statusCode).toEqual(500);
+		expect(res.body).toMatchObject({ error: 'An unexpected error occurred while fetching constituencies' });
+	});
+});
+
+describe('POST /api/v1/constituency', () => {
+  it('should return 201 Created and the created constituency when request is valid', async () => {
+    const newConstituency = {
+      name: 'New Constituency',
+    };
+    const response = await request(app).post(baseRoute).send(newConstituency);
+    expect(response.status).toBe(201);
+    expect(response.body).toMatchObject({
+      message: 'Constituency added successfully',
+      constituency: {
+        _id: expect.any(String),
+        name: newConstituency.name,
+      },
+    });
+  });
+
+  it('should return 400 Bad Request when request is invalid', async () => {
+    const response = await request(app).post(baseRoute).send({});
+    expect(response.status).toBe(400);
+    expect(response.body.errors).toMatchObject({
+			name: 'name is required' 
+		});
+  });
+
+  it('should return 500 Internal Server Error when an unexpected error occurs', async () => {
+    jest.spyOn(Constituency.prototype, 'save').mockRejectedValue(new Error('Unexpected error'));
+		jest.spyOn(console, 'error').mockImplementation(() => { });
+    const response = await request(app).post(baseRoute).send({ name: 'New Constituency' });
+    expect(response.status).toBe(500);
+    expect(response.body).toMatchObject({ error: 'An unexpected error occurred while adding constituency' });
+  });
+});
+
+describe('PATCH /api/v1/constituency/:id', () => {
+  it('should return 200 OK and the updated constituency when request is valid', async () => {
+    const constituency = await Constituency.findOne();
+    const updatedName = 'Updated Constituency';
+    const response = await request(app).patch(`${baseRoute}/${constituency._id.toString()}`).send({ name: updatedName });
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      message: 'Constituency updated successfully',
+      constituency: {
+        _id: constituency._id.toString(),
+        name: updatedName,
+      },
+    });
+  });
+
+  it('should return 400 Bad Request if the ID is invalid', async () => {
+    const response = await request(app).patch(`${baseRoute}/invalid`).send({ name: 'Updated Constituency' });
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({ error: 'Invalid ID: invalid' });
+  });
+
+	it('should return 400 Bad Request if the request is invalid', async () => {
+		const constituency = await Constituency.findOne();
+		const response = await request(app).patch(`${baseRoute}/${constituency._id.toString()}`).send({
+			name: 'z',
+		});
+		expect(response.status).toBe(400);
+		expect(response.body.errors).toMatchObject({
+			name: 'Name must be longer than 2 characters.',
+		});
+	});
+
+  it('should return 404 if the constituency ID is not found', async () => {
+    const response = await request(app).patch(`${baseRoute}/${new mongoose.Types.ObjectId()}`).send({ name: 'Updated Constituency' });
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({ error: 'Constituency not found' });
+  });
+
+	it('should return 500 Internal Server Error when an unexpected error occurs', async () => {
+		mockError('findByIdAndUpdate');
+		const response = await request(app).patch(`${baseRoute}/${new mongoose.Types.ObjectId()}`).send({ name: 'Updated Constituency' });
+		expect(response.status).toBe(500);
+		expect(response.body).toMatchObject({ error: 'An unexpected error occurred while updating constituency' });
+	});
+});
+
+describe('DELETE /api/v1/constituency/:id', () => {
+	it('should return 200 OK when deleting a constituency', async () => {
+		const constituency = await Constituency.findOne();
+		const response = await request(app).delete(`${baseRoute}/${constituency._id.toString()}`);
+		expect(response.body).toMatchObject({
+			message: 'Constituency deleted successfully',
+			constituency: {
+				_id: constituency._id.toString(),
+				name: constituency.name,
+			},
+		});
+		expect(response.status).toBe(200);
+	});
+
+	it('should return 204 No Content when no constituency is found', async () => {
+		const constituency = new mongoose.Types.ObjectId();
+		const response = await request(app).delete(`${baseRoute}/${constituency._id.toString()}`);
+		expect(response.status).toBe(204);
+	});
+
+	it('should return 400 Bad Request when deleting a constituency with an invalid ID', async () => {
+		const response = await request(app).delete(`${baseRoute}/invalid`);
+		expect(response.status).toBe(400);
+	});
+
+	it('should return 500 Internal Server Error when an unexpected error occurs', async () => {
+		mockError('findByIdAndDelete');
+		const response = await request(app).delete(`${baseRoute}/${new mongoose.Types.ObjectId()}`);
+		expect(response.status).toBe(500);
+		expect(response.body).toMatchObject({ error: 'An unexpected error occurred while deleting constituency' });
+	});
+});
+
+afterAll(async () => {
+	server.close();
+	await mongoose.connection.close();
+});

--- a/__test__/routes/electionRoutes.test.js
+++ b/__test__/routes/electionRoutes.test.js
@@ -83,6 +83,6 @@ describe('POST /api/v1/elections/start', () => {
 });
 
 afterAll(async () => {
-	server.close();
 	await mongoose.connection.close();
+	server.close();
 });

--- a/__test__/routes/nominationDistrictRoutes.test.js
+++ b/__test__/routes/nominationDistrictRoutes.test.js
@@ -33,7 +33,7 @@ jest.unstable_mockModule('../../middleware/verifyToken.js', () => {
 const mockError = (method) => {
 	jest.spyOn(NominationDistrict, method).mockRejectedValue(new Error('Unexpected error'));
 	jest.spyOn(console, 'error').mockImplementation(() => { });
-}
+};
 
 describe('GET /', () => {
 	it('should return all nomination districts if no query is given', async () => {
@@ -120,7 +120,7 @@ describe('POST /', () => {
 				name: 'name is required',
 				constituency: 'constituency is required',
 			},
-		})
+		});
 	});
 
 	const testInvalidFields = async (newNominationDistrict, expectedErrors) => {

--- a/__test__/routes/nominationDistrictRoutes.test.js
+++ b/__test__/routes/nominationDistrictRoutes.test.js
@@ -1,0 +1,77 @@
+import request from 'supertest';
+import express from 'express';
+import mongoose from 'mongoose';
+import connectDb from '../setup/connect.js';
+import { jest } from '@jest/globals';
+import mockData from '../db/mockData.js';
+import populateDb from '../db/testPopulation.js';
+import NominationDistrict from '../../schemas/NominationDistrict.js';
+import Constituency from '../../schemas/Constituency.js';
+
+let router;
+const baseRoute = '/api/v1/nominationDistricts';
+
+const app = express();
+app.use(express.json());
+app.use(baseRoute, async (req, res, next) => (await router)(req, res, next));
+
+const server = app.listen(0);
+
+beforeAll(async () => {
+	connectDb();
+	router = (await import('../../routes/nominationDistrictRoutes.js')).default;
+
+	await populateDb();
+});
+
+jest.unstable_mockModule('../../middleware/verifyToken.js', () => {
+	return {
+		auth: jest.fn((req, res, next) => next()),
+	};
+});
+
+describe('GET /', () => {
+	it('should return all nomination districts if no query is given', async () => {
+		const res = await request(app).get(baseRoute);
+		expect(res.statusCode).toEqual(200);
+		expect(res.body.length).toBe(mockData.nominationDistricts.length);
+		res.body.forEach((nominationDistrict) => {
+			expect(nominationDistrict).toMatchObject({
+				name: expect.any(String),
+				constituency: expect.any(String),
+			});
+		});
+	});
+
+	it('should return a filtered list of nomination districts if a valid query is given', async () => {
+		const constituencyId = await Constituency.findOne().then((constituency) => constituency._id);
+		const res = await request(app).get(`${baseRoute}?constituency=${constituencyId.toString()}`);
+		expect(res.statusCode).toEqual(200);
+		expect(res.body.length).toBeGreaterThan(0);
+		expect(res.body[0]).toMatchObject({
+			name: expect.any(String),
+			constituency: expect.any(String),
+		});
+	});
+
+	it('should return an empty list if no nomination districts match the query', async () => {
+		const res = await request(app).get(`${baseRoute}?name=NonExistentNominationDistrict`);
+		expect(res.statusCode).toEqual(200);
+		expect(res.body.length).toBe(0);
+	});
+
+	it('should return a 500 error if an unexpected error occurs', async () => {
+		jest.spyOn(mongoose.Model, 'find').mockRejectedValue(new Error('Unexpected error'));
+		jest.spyOn(console, 'error').mockImplementation(() => {});
+		const res = await request(app).get(baseRoute);
+		expect(res.statusCode).toEqual(500);
+		expect(res.body).toMatchObject({
+			error: 'An unexpected error occurred while fetching nomination districts',
+		});
+	});
+});
+
+afterAll(async () => {
+	await mongoose.connection.close();
+	server.close();
+});

--- a/__test__/routes/nominationDistrictRoutes.test.js
+++ b/__test__/routes/nominationDistrictRoutes.test.js
@@ -72,6 +72,7 @@ describe('GET /', () => {
 });
 
 afterAll(async () => {
+	await mongoose.connection.db.dropDatabase();
 	await mongoose.connection.close();
 	server.close();
 });

--- a/__test__/routes/nominationDistrictRoutes.test.js
+++ b/__test__/routes/nominationDistrictRoutes.test.js
@@ -30,6 +30,11 @@ jest.unstable_mockModule('../../middleware/verifyToken.js', () => {
 	};
 });
 
+const mockError = (method) => {
+	jest.spyOn(NominationDistrict, method).mockRejectedValue(new Error('Unexpected error'));
+	jest.spyOn(console, 'error').mockImplementation(() => { });
+}
+
 describe('GET /', () => {
 	it('should return all nomination districts if no query is given', async () => {
 		const res = await request(app).get(baseRoute);
@@ -60,13 +65,228 @@ describe('GET /', () => {
 		expect(res.body.length).toBe(0);
 	});
 
+	it('should return a 400 error if an invalid query is given', async () => {
+		const res = await request(app).get(`${baseRoute}?invalidQuery=InvalidValue`);
+		expect(res.statusCode).toEqual(400);
+		expect(res.body).toMatchObject({
+			error: 'Invalid query parameter: invalidQuery',
+		});
+	});
+
+	it('should return a 400 error if an invalid ID is given', async () => {
+		const res = await request(app).get(`${baseRoute}?constituency=InvalidId`);
+		expect(res.statusCode).toEqual(400);
+		expect(res.body).toMatchObject({
+			error: 'Invalid ID: InvalidId',
+		});
+	});
+
 	it('should return a 500 error if an unexpected error occurs', async () => {
 		jest.spyOn(mongoose.Model, 'find').mockRejectedValue(new Error('Unexpected error'));
-		jest.spyOn(console, 'error').mockImplementation(() => {});
+		jest.spyOn(console, 'error').mockImplementation(() => { });
 		const res = await request(app).get(baseRoute);
 		expect(res.statusCode).toEqual(500);
 		expect(res.body).toMatchObject({
 			error: 'An unexpected error occurred while fetching nomination districts',
+		});
+	});
+});
+
+describe('POST /', () => {
+	it('should return 201 Created and the created nomination district if all fields are valid', async () => {
+		const constituencyId = await Constituency.findOne().then((constituency) => constituency._id);
+		const newNominationDistrict = {
+			name: 'New Nomination District',
+			constituency: constituencyId,
+		};
+		const res = await request(app).post(baseRoute).send(newNominationDistrict);
+		expect(res.statusCode).toEqual(201);
+		expect(res.body).toMatchObject({
+			message: 'Nomination district added successfully',
+			nominationDistrict: {
+				_id: expect.any(String),
+				name: newNominationDistrict.name,
+				constituency: newNominationDistrict.constituency.toString(),
+			},
+		});
+	});
+
+	it('should return a 400 error if fields are missing', async () => {
+		const newNominationDistrict = {};
+		const res = await request(app).post(baseRoute).send(newNominationDistrict);
+		expect(res.statusCode).toEqual(400);
+		expect(res.body).toMatchObject({
+			errors: {
+				name: 'name is required',
+				constituency: 'constituency is required',
+			},
+		})
+	});
+
+	const testInvalidFields = async (newNominationDistrict, expectedErrors) => {
+		const res = await request(app).post(baseRoute).send(newNominationDistrict);
+		expect(res.statusCode).toEqual(400);
+		expect(res.body).toMatchObject({ errors: expectedErrors });
+	};
+
+	it('should return a 400 error if fields are invalid (1)', async () => {
+		const newNominationDistrict = {
+			name: 'New Nomination District',
+			constituency: 'InvalidId',
+		};
+		const expectedErrors = {
+			constituency: '\'InvalidId\' (type string) is not a valid ObjectId',
+		};
+		await testInvalidFields(newNominationDistrict, expectedErrors);
+	});
+
+	it('should return a 400 error if fields are invalid (2)', async () => {
+		const newNominationDistrict = {
+			name: 'Ne',
+			constituency: 'InvalidId',
+		};
+		const expectedErrors = {
+			name: 'Name must be longer than 2 characters.',
+			constituency: '\'InvalidId\' (type string) is not a valid ObjectId',
+		};
+		await testInvalidFields(newNominationDistrict, expectedErrors);
+	});
+
+	it('should return a 500 error if an unexpected error occurs', async () => {
+		jest.spyOn(NominationDistrict.prototype, 'save').mockRejectedValue(new Error('Unexpected error'));
+		jest.spyOn(console, 'error').mockImplementation(() => { });
+		const newNominationDistrict = {
+			name: 'New Nomination District',
+			constituency: await Constituency.findOne().then((constituency) => constituency._id),
+		};
+		const res = await request(app).post(baseRoute).send(newNominationDistrict);
+		expect(res.statusCode).toEqual(500);
+		expect(res.body).toMatchObject({
+			error: 'An unexpected error occurred while adding nomination district',
+		});
+	});
+
+});
+
+describe('PATCH /:id', () => {
+	it('should return 200 OK and the updated nomination district if the ID and body is valid', async () => {
+		const nominationDistrictId = await NominationDistrict.findOne().then((nominationDistrict) => nominationDistrict._id);
+		const updatedNominationDistrict = {
+			name: 'Updated Nomination District',
+		};
+		const res = await request(app).patch(`${baseRoute}/${nominationDistrictId}`).send(updatedNominationDistrict);
+		expect(res.statusCode).toEqual(200);
+		expect(res.body).toMatchObject({
+			message: 'Nomination district updated successfully',
+			nominationDistrict: {
+				_id: nominationDistrictId.toString(),
+				name: updatedNominationDistrict.name,
+				constituency: expect.any(String),
+			},
+		});
+	});
+
+	it('should return 400 Bad Request if the ID is invalid', async () => {
+		const updatedNominationDistrict = {
+			name: 'Updated Nomination District',
+		};
+		const res = await request(app).patch(`${baseRoute}/InvalidId`).send(updatedNominationDistrict);
+		expect(res.statusCode).toEqual(400);
+		expect(res.body).toMatchObject({
+			error: 'Invalid ID: InvalidId',
+		});
+	});
+
+	it('should return 404 Not Found if the ID does not exist', async () => {
+		const updatedNominationDistrict = {
+			name: 'Updated Nomination District',
+		};
+		const res = await request(app).patch(`${baseRoute}/${new mongoose.Types.ObjectId()}`).send(updatedNominationDistrict);
+		expect(res.statusCode).toEqual(404);
+		expect(res.body).toMatchObject({
+			error: 'Nomination district not found',
+		});
+	});
+
+	const testInvalidPatchRequest = async (nominationDistrictId, updatedNominationDistrict, expectedErrors) => {
+		const res = await request(app).patch(`${baseRoute}/${nominationDistrictId}`).send(updatedNominationDistrict);
+		expect(res.statusCode).toEqual(400);
+		expect(res.body).toMatchObject({ errors: expectedErrors });
+	};
+
+	it('should return 400 Bad Request if the body is invalid (1)', async () => {
+		const nominationDistrict = await NominationDistrict.findOne();
+		const updatedNominationDistrict = {
+			name: 'Ne',
+		};
+		const expectedErrors = {
+			name: 'Name must be longer than 2 characters.',
+		};
+		await testInvalidPatchRequest(nominationDistrict._id, updatedNominationDistrict, expectedErrors);
+	});
+
+	it('should return 400 Bad Request if the body is invalid (2)', async () => {
+		const nominationDistrictId = await NominationDistrict.findOne().then((nominationDistrict) => nominationDistrict._id);
+		const updatedNominationDistrict = {
+			name: 'Up',
+			constituency: 'InvalidId',
+		};
+		const expectedErrors = {
+			constituency: '\'InvalidId\' (type string) is not a valid ObjectId',
+		};
+		await testInvalidPatchRequest(nominationDistrictId, updatedNominationDistrict, expectedErrors);
+	});
+
+	it('should return 500 Internal Server Error if an unexpected error occurs', async () => {
+		mockError('findByIdAndUpdate');
+		const nominationDistrictId = await NominationDistrict.findOne().then((nominationDistrict) => nominationDistrict._id);
+		const updatedNominationDistrict = {
+			name: 'Updated Nomination District',
+		};
+		const res = await request(app).patch(`${baseRoute}/${nominationDistrictId}`).send(updatedNominationDistrict);
+		expect(res.statusCode).toEqual(500);
+		expect(res.body).toMatchObject({
+			error: 'An unexpected error occurred while updating nomination district',
+		});
+	});
+});
+
+describe('DELETE /:id', () => {
+	it('should return 200 OK and the deleted nomination district if the ID is valid', async () => {
+		const nominationDistrictId = await NominationDistrict.findOne().then((nominationDistrict) => nominationDistrict._id);
+		const res = await request(app).delete(`${baseRoute}/${nominationDistrictId}`);
+		expect(res.statusCode).toEqual(200);
+		expect(res.body).toMatchObject({
+			message: 'Nomination district deleted successfully',
+			nominationDistrict: {
+				_id: nominationDistrictId.toString(),
+				name: expect.any(String),
+				constituency: expect.any(String),
+			},
+		});
+	});
+
+	it('should return 400 Bad Request if the ID is invalid', async () => {
+		const res = await request(app).delete(`${baseRoute}/InvalidId`);
+		expect(res.statusCode).toEqual(400);
+		expect(res.body).toMatchObject({
+			error: 'Invalid ID: InvalidId',
+		});
+	});
+
+	it('should return 204 No Content if no nominationDistrict is found', async () => {
+		const res = await request(app).delete(`${baseRoute}/${new mongoose.Types.ObjectId()}`);
+		expect(res.statusCode).toEqual(204);
+		expect(res.body).toMatchObject({});
+	});
+
+	it('should return 500 Internal Server Error if an unexpected error occurs', async () => {
+		mockError('findByIdAndDelete');
+		const nominationDistrictId = await NominationDistrict.findOne().then((nominationDistrict) => nominationDistrict._id);
+		const res = await request(app).delete(`${baseRoute}/${nominationDistrictId}`);
+		expect(res.statusCode).toEqual(500);
+		expect(res.body).toMatchObject({
+			error: 'An unexpected error occurred while deleting nomination district',
 		});
 	});
 });

--- a/__test__/routes/partyRoutes.test.js
+++ b/__test__/routes/partyRoutes.test.js
@@ -34,6 +34,60 @@ const mongoDbFields = {
 	__v: expect.any(Number),
 };
 
+describe('GET /api/v1/parties', () => {
+	it('should return 200 OK and all parties when no query is given', async () => {
+		const response = await request(app).get(baseRoute);
+		expect(response.statusCode).toBe(200);
+		expect(response.body.length).toBe(mockData.parties.length);
+		response.body.forEach((party) => {
+			expect(party).toMatchObject({
+				...mongoDbFields,
+				name: expect.any(String),
+				list: expect.any(String),
+			});
+		});
+	});
+
+	it('should return 200 OK and filtered parties when a query is given', async () => {
+		const response = await request(app).get(`${baseRoute}?list=U`);
+		expect(response.statusCode).toBe(200);
+		expect(response.body.length).toBe(1);
+		response.body.forEach((party) => {
+			expect(party).toMatchObject({
+				...mongoDbFields,
+				name: expect.any(String),
+				list: 'U',
+			});
+		});
+	});
+
+	it('should return 200 OK and an empty array when no parties match the query', async () => {
+		const response = await request(app).get(`${baseRoute}?list=Z`);
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toEqual([]);
+	});
+
+	it('should return 400 Bad Request when an invalid query is given', async () => {
+		const response = await request(app).get(`${baseRoute}?invalidQuery=invalid`);
+		expect(response.statusCode).toBe(400);
+		expect(response.body.error).toBe('Invalid query parameter: invalidQuery');
+	});
+
+	it('should return 400 Bad Request when an invalid ID is given', async () => {
+		const response = await request(app).get(`${baseRoute}?_id=invalidId`);
+		expect(response.statusCode).toBe(400);
+		expect(response.body.error).toBe('Invalid ID: invalidId');
+	});
+
+	it('should return 500 Internal Server Error when an unexpected error occurs', async () => {
+		jest.spyOn(Party, 'find').mockRejectedValue(new Error('Unexpected error'));
+		jest.spyOn(console, 'error').mockImplementation(() => {});
+		const response = await request(app).get(baseRoute);
+		expect(response.statusCode).toBe(500);
+		expect(response.body.error).toBe('An unexpected error occurred while fetching parties');
+	});
+});
+
 describe('POST /api/v1/parties', () => {
 	it('should return 201 Created when party fields are valid', async () => {
 		const response = await request(app).post(baseRoute).send({

--- a/__test__/routes/partyRoutes.test.js
+++ b/__test__/routes/partyRoutes.test.js
@@ -17,6 +17,7 @@ const server = app.listen(0);
 
 beforeAll(async () => {
 	connectDb();
+	await Party.deleteMany();
 	await Party.insertMany(mockData.parties);
 	router = (await import('../../routes/partyRoutes.js')).default;
 });
@@ -340,7 +341,7 @@ describe('DELETE /api/v1/parties/:id', () => {
 });
 
 afterAll(async () => {
-	server.close();
 	await Party.deleteMany();
 	await mongoose.connection.close();
+	server.close();
 });

--- a/__test__/routes/pollingStationRoutes.test.js
+++ b/__test__/routes/pollingStationRoutes.test.js
@@ -6,7 +6,6 @@ import { jest } from '@jest/globals';
 import mockData from '../db/mockData.js';
 import populateDb from '../db/testPopulation.js';
 import NominationDistrict from '../../schemas/NominationDistrict.js';
-import Constituency from '../../schemas/Constituency.js';
 import PollingStation from '../../schemas/PollingStation.js';
 
 let router;
@@ -33,7 +32,7 @@ jest.unstable_mockModule('../../middleware/verifyToken.js', () => {
 const mockError = (method) => {
 	jest.spyOn(PollingStation, method).mockRejectedValue(new Error('Unknown error'));
 	jest.spyOn(console, 'error').mockImplementation(() => { });
-}
+};
 
 const testInvalidErrors = async (method, route, data, expectedErrors) => {
 	const res = await request(app)[method](route).send(data);
@@ -232,7 +231,6 @@ describe('PATCH /:id', () => {
 			nominationDistrict: nominationDistrict._id.toString(),
 			expectedVoters: 100,
 		});
-		console.log(res.body);
 		expect(res.status).toBe(404);
 		expect(res.body.error).toBe('Polling station not found');
 	});

--- a/__test__/routes/pollingStationRoutes.test.js
+++ b/__test__/routes/pollingStationRoutes.test.js
@@ -1,0 +1,295 @@
+import request from 'supertest';
+import express from 'express';
+import mongoose from 'mongoose';
+import connectDb from '../setup/connect.js';
+import { jest } from '@jest/globals';
+import mockData from '../db/mockData.js';
+import populateDb from '../db/testPopulation.js';
+import NominationDistrict from '../../schemas/NominationDistrict.js';
+import Constituency from '../../schemas/Constituency.js';
+import PollingStation from '../../schemas/PollingStation.js';
+
+let router;
+const baseRoute = '/api/v1/parties';
+
+const app = express();
+app.use(express.json());
+app.use(baseRoute, async (req, res, next) => (await router)(req, res, next));
+
+const server = app.listen(0);
+
+beforeAll(async () => {
+	connectDb();
+	await populateDb();
+	router = (await import('../../routes/pollingStationRoutes.js')).default;
+});
+
+jest.unstable_mockModule('../../middleware/verifyToken.js', () => {
+	return {
+		auth: jest.fn((req, res, next) => next()),
+	};
+});
+
+const mockError = (method) => {
+	jest.spyOn(PollingStation, method).mockRejectedValue(new Error('Unknown error'));
+	jest.spyOn(console, 'error').mockImplementation(() => { });
+}
+
+const testInvalidErrors = async (method, route, data, expectedErrors) => {
+	const res = await request(app)[method](route).send(data);
+	expect(res.status).toBe(400);
+	expect(res.body.errors).toEqual(expectedErrors);
+};
+
+describe('GET /', () => {
+	it('should return 200 OK and a list of all parties when no query is given', async () => {
+		const res = await request(app).get(baseRoute);
+		expect(res.status).toBe(200);
+		expect(res.body.length).toBe(mockData.pollingStations.length);
+		res.body.forEach((party) => {
+			expect(party).toMatchObject({
+				name: expect.any(String),
+				_id: expect.any(String),
+				nominationDistrict: expect.any(String),
+				expectedVoters: expect.any(Number),
+			});
+		});
+	});
+
+	it('should return 200 OK and a list of polling stations filtered by name', async () => {
+		const res = await request(app).get(baseRoute).query({ name: 'Polling Station 1' });
+		expect(res.status).toBe(200);
+		expect(res.body.length).toBe(1);
+		expect(res.body[0].name).toBe('Polling Station 1');
+	});
+
+	it('should return 200 OK and a list of polling stations filtered by nomination district', async () => {
+		const nominationDistrict = await NominationDistrict.findOne();
+		const res = await request(app).get(baseRoute).query({ nominationDistrict: nominationDistrict._id.toString() });
+		expect(res.status).toBe(200);
+		expect(res.body.length).toBe(mockData.pollingStations.filter((station) => station.nominationDistrict === nominationDistrict.name).length);
+		res.body.forEach((station) => {
+			expect(station).toMatchObject({
+				name: expect.any(String),
+				_id: expect.any(String),
+				nominationDistrict: nominationDistrict._id.toString(),
+				expectedVoters: expect.any(Number),
+			});
+		});
+	});
+
+	it('should return 200 OK and an empty list if no polling stations match the query', async () => {
+		const res = await request(app).get(baseRoute).query({ name: 'Invalid Polling Station' });
+		expect(res.status).toBe(200);
+		expect(res.body.length).toBe(0);
+	});
+
+	it('should return 400 Bad Request when an invalid query is given', async () => {
+		const res = await request(app).get(baseRoute).query({ invalid: 'invalid' });
+		expect(res.status).toBe(400);
+		expect(res.body.error).toBe('Invalid query parameter: invalid');
+	});
+
+	it('should return 400 Bad Request when an invalid _id is given', async () => {
+		const res = await request(app).get(baseRoute).query({ _id: 'invalid' });
+		expect(res.status).toBe(400);
+		expect(res.body.error).toBe('Invalid ID: invalid');
+	});
+
+	it('should return 500 Internal Server Error when an unexpected error occurs', async () => {
+		mockError('find');
+		const res = await request(app).get(baseRoute);
+		expect(res.status).toBe(500);
+		expect(res.body.error).toBe('An unexpected error occurred while fetching polling stations');
+	});
+});
+
+describe('POST /', () => {
+	it('should return 201 Created and the added polling station when a valid polling station is given', async () => {
+		const nominationDistrict = await NominationDistrict.findOne();
+		const res = await request(app).post(baseRoute).send({
+			name: 'New Polling Station',
+			nominationDistrict: nominationDistrict._id.toString(),
+			expectedVoters: 100,
+		});
+		expect(res.status).toBe(201);
+		expect(res.body.message).toBe('Polling station added successfully');
+		expect(res.body.pollingStation).toMatchObject({
+			name: 'New Polling Station',
+			nominationDistrict: nominationDistrict._id.toString(),
+			expectedVoters: 100,
+			_id: expect.any(String),
+		});
+	});
+
+	it('should return 400 Bad Request when a polling station with an invalid nomination district is given', async () => {
+		const res = await request(app).post(baseRoute).send({
+			name: 'Invalid Polling Station',
+			nominationDistrict: 'invalid',
+			expectedVoters: 100,
+		});
+		expect(res.status).toBe(400);
+		expect(res.body.errors).toEqual({
+			nominationDistrict: '\'invalid\' (type string) is not a valid ObjectId',
+		});
+	});
+
+	it('should return 400 Bad Request when a polling station with a missing name is given', async () => {
+		const res = await request(app).post(baseRoute).send({
+			nominationDistrict: 'invalid',
+			expectedVoters: 100,
+		});
+		expect(res.status).toBe(400);
+		expect(res.body.errors).toEqual({
+			nominationDistrict: '\'invalid\' (type string) is not a valid ObjectId',
+			name: 'name is required',
+		});
+	});
+
+	it('should return 500 Internal Server Error when an unexpected error occurs', async () => {
+		jest.spyOn(PollingStation.prototype, 'save').mockRejectedValue(new Error('Unknown error'));
+		jest.spyOn(console, 'error').mockImplementation(() => { });
+		const res = await request(app).post(baseRoute).send({
+			name: 'New Polling Station',
+			nominationDistrict: 'invalid',
+			expectedVoters: 100,
+		});
+		expect(res.status).toBe(500);
+		expect(res.body.error).toBe('An unexpected error occurred while adding polling station');
+	});
+});
+
+describe('PATCH /:id', () => {
+	it('should return 200 OK and the updated polling station when a valid polling station is given', async () => {
+		const pollingStation = await PollingStation.findOne();
+		const nominationDistrict = await NominationDistrict.findOne();
+		const res = await request(app).patch(`${baseRoute}/${pollingStation._id}`).send({
+			name: 'Updated Polling Station',
+			nominationDistrict: nominationDistrict._id.toString(),
+			expectedVoters: 100,
+		});
+		expect(res.status).toBe(200);
+		expect(res.body).toMatchObject({
+			message: 'Polling station updated successfully',
+			pollingStation: {
+				name: 'Updated Polling Station',
+				nominationDistrict: nominationDistrict._id.toString(),
+				expectedVoters: 100,
+				_id: pollingStation._id.toString(),
+			},
+		});
+	});
+
+	it('should return 400 Bad Request when an invalid _id is given', async () => {
+		const res = await request(app).patch(`${baseRoute}/invalid`).send({
+			name: 'Updated Polling Station',
+			nominationDistrict: 'invalid',
+			expectedVoters: 100,
+		});
+		expect(res.status).toBe(400);
+		expect(res.body.error).toBe('Invalid ID: invalid');
+	});
+
+	it('should return 400 Bad Request when a polling station with an invalid nomination district is given', async () => {
+		const pollingStation = await PollingStation.findOne();
+		await testInvalidErrors('patch', `${baseRoute}/${pollingStation._id}`, {
+			name: 'Updated Polling Station',
+			nominationDistrict: 'invalid',
+			expectedVoters: 100,
+		}, {
+			nominationDistrict: '\'invalid\' (type string) is not a valid ObjectId',
+		});
+	});
+
+	it('should return 400 Bad Request when a polling station with a missing name is given', async () => {
+		const pollingStation = await PollingStation.findOne();
+		const res = await request(app).patch(`${baseRoute}/${pollingStation._id}`).send({
+			nominationDistrict: 'invalid',
+			expectedVoters: 100,
+		});
+		expect(res.status).toBe(400);
+		expect(res.body.errors).toEqual({
+			nominationDistrict: '\'invalid\' (type string) is not a valid ObjectId',
+		});
+	});
+
+	it('should return 400 Bad Request when a polling station with an invalid name is given', async () => {
+		const pollingStation = await PollingStation.findOne();
+		const res = await request(app).patch(`${baseRoute}/${pollingStation._id}`).send({
+			name: 'Up',
+			expectedVoters: 100,
+		});
+		expect(res.status).toBe(400);
+		expect(res.body.errors).toEqual({
+			name: 'Name must be longer than 2 characters.',
+		});
+	});
+
+	it('should return 404 Not Found when a non-existent polling station ID is given', async () => {
+		const nominationDistrict = await NominationDistrict.findOne();
+		const res = await request(app).patch(`${baseRoute}/${new mongoose.Types.ObjectId()}`).send({
+			name: 'Updated Polling Station',
+			nominationDistrict: nominationDistrict._id.toString(),
+			expectedVoters: 100,
+		});
+		console.log(res.body);
+		expect(res.status).toBe(404);
+		expect(res.body.error).toBe('Polling station not found');
+	});
+
+	it('should return 500 Internal Server Error when an unexpected error occurs', async () => {
+		mockError('findByIdAndUpdate');
+		const pollingStation = await PollingStation.findOne();
+		const nominationDistrict = await NominationDistrict.findOne();
+		const res = await request(app).patch(`${baseRoute}/${pollingStation._id}`).send({
+			name: 'Updated Polling Station',
+			nominationDistrict: nominationDistrict._id.toString(),
+			expectedVoters: 100,
+		});
+		expect(res.status).toBe(500);
+		expect(res.body.error).toBe('An unexpected error occurred while updating polling station');
+	});
+});
+
+describe('DELETE /:id', () => {
+	it('should return 200 OK and the deleted polling station when a valid polling station ID is given', async () => {
+		const pollingStation = await PollingStation.findOne();
+		const res = await request(app).delete(`${baseRoute}/${pollingStation._id}`);
+		expect(res.status).toBe(200);
+		expect(res.body).toMatchObject({
+			message: 'Polling station deleted successfully',
+			pollingStation: {
+				name: pollingStation.name,
+				nominationDistrict: pollingStation.nominationDistrict.toString(),
+				expectedVoters: pollingStation.expectedVoters,
+				_id: pollingStation._id.toString(),
+			},
+		});
+	});
+
+	it('should return 400 Bad Request when an invalid _id is given', async () => {
+		const res = await request(app).delete(`${baseRoute}/invalid`);
+		expect(res.status).toBe(400);
+		expect(res.body.error).toBe('Invalid ID: invalid');
+	});
+
+	it('should return 204 No Content when a non-existent polling station ID is given', async () => {
+		const res = await request(app).delete(`${baseRoute}/${new mongoose.Types.ObjectId()}`);
+		expect(res.status).toBe(204);
+		expect(res.body).toEqual({});
+	});
+
+	it('should return 500 Internal Server Error when an unexpected error occurs', async () => {
+		mockError('findByIdAndDelete');
+		const pollingStation = await PollingStation.findOne();
+		const res = await request(app).delete(`${baseRoute}/${pollingStation._id}`);
+		expect(res.status).toBe(500);
+		expect(res.body.error).toBe('An unexpected error occurred while deleting polling station');
+	});
+});
+
+
+afterAll(async () => {
+	server.close();
+	await mongoose.connection.close();
+});

--- a/__test__/utils/handleQuery.test.js
+++ b/__test__/utils/handleQuery.test.js
@@ -1,0 +1,95 @@
+// Tests for /utils/handleQuery.js
+
+import handleQuery from '../../utils/handleQuery.js';
+
+describe('handleQuery', () => {
+	it('should return an object with a filter key', () => {
+		const query = { name: 'test' };
+		const model = { schema: { paths: { name: {} } } };
+		const result = handleQuery(query, model);
+
+		expect(result).toHaveProperty('name');
+	});
+
+	it('should throw an error if the query parameter is invalid', () => {
+		const query = { invalid: 'test' };
+		const model = { schema: { paths: { name: {} } } };
+
+		expect(() => handleQuery(query, model)).toThrow(
+			'Invalid query parameter: invalid'
+		);
+	});
+
+	it('should return an object with a populate key if defined in query', () => {
+		const query = { populate: true };
+		const model = { schema: { paths: { name: {} } } };
+		const result = handleQuery(query, model);
+
+		expect(result).toHaveProperty('populate');
+	});
+
+	it('should split comma separated values for strings', () => {
+		const query = { name: 'test1,test2' };
+		const model = { schema: { paths: { name: {} } } };
+		const result = handleQuery(query, model);
+
+		expect(result.name).toEqual(['test1', 'test2']);
+	});
+
+	it('should split comma separated values for strings (one value/no comma)', () => {
+		const query = { name: 'test' };
+		const model = { schema: { paths: { name: {} } } };
+		const result = handleQuery(query, model);
+
+		expect(result.name).toEqual(['test']);
+	});
+
+	it('should sanitize string values', () => {
+		const query = { name: 'test^(!=?' };
+		const model = { schema: { paths: { name: {} } } };
+		const result = handleQuery(query, model);
+
+		expect(result.name).toEqual(['test']);
+	});
+
+	it('should sanitize string values (multiple values)', () => {
+		const query = { name: 'test1^(!=?,test2^(!=?' };
+		const model = { schema: { paths: { name: {} } } };
+		const result = handleQuery(query, model);
+
+		expect(result.name).toEqual(['test1', 'test2']);
+	});
+
+	it('should take both numbers, strings, booleans, null values, and arrays', () => {
+		const query = { name: 'test1,test2', number: 123, arrayNum: [1, 2, 3], arrayStr: ['test1', 'test2'], bool: true, null: null };
+		const model = { schema: { paths: { name: {}, number: {}, arrayNum: {}, arrayStr: {}, bool: {}, null: {} } } };
+		const result = handleQuery(query, model);
+
+		expect(result).toEqual({
+			name: ['test1', 'test2'],
+			number: 123,
+			arrayNum: [1, 2, 3],
+			arrayStr: ['test1', 'test2'],
+			bool: true,
+			null: null
+		});
+	});
+
+	it('should just keep undefined values (mongoose will ignore them)', () => {
+		const query = { name: undefined };
+		const model = { schema: { paths: { name: {} } } };
+		const result = handleQuery(query, model);
+
+		expect(result).toEqual({ name: undefined });
+	});
+
+	it('should handle empty strings', () => {
+		const query = { name: '' };
+		const model = { schema: { paths: { name: {} } } };
+		const result = handleQuery(query, model);
+
+		expect(result).toEqual({ name: [''] });
+	});
+
+
+});

--- a/controllers/candidate.js
+++ b/controllers/candidate.js
@@ -1,12 +1,40 @@
 import Candidate from '../schemas/Candidate.js';
+import handleQuery from '../utils/handleQuery.js';
 import validationError, { checkIdsAndGiveErrors } from '../utils/validationError.js';
 
+
 /**
- * Add a candidate to the database
- * @param {Request} req Request object containing the candidate object in the body
+ * Fetch candidates from the database
+ * @param {Request} req Express request object possibly containing query parameters (e.g. party, nominationDistrict)
  * @param {Response} res Express response object to send the response
- * @returns {Response} Success or error message
+ * @returns {Response} A list of candidates or an error message
  */
+async function fetchCandidates(req, res) {
+  try {
+    const query = handleQuery(req.query, Candidate);
+    const candidates = await Candidate.find(query);
+    return res.status(200).json(candidates);
+  } catch (error) {
+    if (error.message.includes('Invalid query parameter')) {
+      return res.status(400).json({
+        error: error.message,
+      });
+    }
+    
+    if (error.name === 'CastError') {
+      return res.status(400).json({
+        error: 'Invalid ID: ' + error.value,
+      });
+    }
+
+    // eslint-disable-next-line no-console
+    console.error(`Error fetching candidates: ${error.message}`);
+    return res.status(500).json({
+      error: 'An unexpected error occurred while fetching candidates',
+    });
+  }
+}
+
 /**
  * Add a candidate to the database
  * @param {Request} req Request object containing the candidate object in the body
@@ -119,7 +147,7 @@ async function deleteCandidate(req, res) {
   }
 }
 
-export { addCandidate, updateCandidate, deleteCandidate };
+export { fetchCandidates, addCandidate, updateCandidate, deleteCandidate };
 
 /**
  * @import { Request, Response } from 'express';

--- a/controllers/constituency.js
+++ b/controllers/constituency.js
@@ -1,0 +1,151 @@
+import Constituency from '../schemas/Constituency.js';
+import handleQuery from '../utils/handleQuery.js';
+import validationError, { validateSingleObjectId } from '../utils/validationError.js';
+
+
+/**
+ * Fetch nomination districts from the database
+ * @param {Request} req Express request object with query parameters
+ * @param {Response} res Express response object
+ * @returns {Response} Response object with the constituencies
+ */
+async function fetchConstituencies(req, res) {
+	try {
+		const query = handleQuery(req.query, Constituency);
+		const constituencies = await Constituency.find(query);
+		return res.status(200).json( constituencies );
+	} catch (error) {
+		if (error.message.includes('Invalid query parameter')) {
+			return res.status(400).json({
+				error: error.message,
+			});
+		}
+
+		if (error.name === 'CastError') {
+			return res.status(400).json({
+				error: 'Invalid ID: ' + error.value,
+			});
+		}
+
+		// eslint-disable-next-line no-console
+		console.error(`Error fetching constituencies: ${error.message}`);
+		return res.status(500).json({
+			error: 'An unexpected error occurred while fetching constituencies',
+		});
+	}
+}
+
+/**
+ * Add a new constituency to the database
+ * @param {Request} req Express request object with constituency details
+ * @param {Response} res Express response object
+ * @returns {Response} Response object with the added constituency
+ */
+async function addConstituency(req, res) {
+	const constituency = req.body;
+	const newConstituency = new Constituency(constituency);
+
+	try {
+		await newConstituency.save();
+		return res.status(201).json({
+			message: 'Constituency added successfully',
+			constituency: newConstituency,
+		});
+	} catch (error) {
+		if (error.name === 'ValidationError') {
+			return res.status(400).json({
+				errors: validationError(error),
+			});
+		}
+		// eslint-disable-next-line no-console
+		console.error(`Error adding constituency: ${error.message}`);
+		return res.status(500).json({
+			error: 'An unexpected error occurred while adding constituency',
+		});
+	}
+}
+
+/**
+ * Update a constituency in the database
+ * @param {Request} req Express request object with constituency ID and details
+ * @param {Response} res Express response object
+ * @returns {Response} Response object with the updated constituency
+ */
+async function updateConstituency(req, res) {
+	const { id } = req.params;
+	const constituency = req.body;
+
+	if (!validateSingleObjectId(id)) {
+		return res.status(400).json({
+			error: 'Invalid ID: ' + id,
+		});
+	}
+
+	try {
+		const updatedConstituency = await Constituency.findByIdAndUpdate(id, constituency, { new: true, runValidators: true });
+		if (!updatedConstituency) {
+			return res.status(404).json({
+				error: 'Constituency not found',
+			});
+		}
+
+		return res.status(200).json({
+			message: 'Constituency updated successfully',
+			constituency: updatedConstituency,
+		});
+
+	} catch (error) {
+		if (error.name === 'ValidationError') {
+			return res.status(400).json({
+				errors: validationError(error),
+			});
+		}
+
+		// eslint-disable-next-line no-console
+		console.error(`Error updating constituency: ${error.message}`);
+		return res.status(500).json({
+			error: 'An unexpected error occurred while updating constituency',
+		});
+	}
+}
+
+/**
+ * Delete a constituency from the database
+ * @param {Request} req Express request object with constituency ID
+ * @param {Response} res Express response object
+ * @returns {Response} Response object with the deleted constituency
+ */
+async function deleteConstituency(req, res) {
+	const { id } = req.params;
+
+	if (!validateSingleObjectId(id)) {
+		return res.status(400).json({
+			error: 'Invalid ID: ' + id
+		});
+	}
+
+	try {
+		const deletedConstituency = await Constituency.findByIdAndDelete(id);
+
+		if (!deletedConstituency) {
+			return res.status(204).send();
+		}
+
+		return res.status(200).json({
+			message: 'Constituency deleted successfully',
+			constituency: deletedConstituency,
+		});
+	} catch (error) {
+		// eslint-disable-next-line no-console
+		console.error(`Error deleting constituency: ${error.message}`);
+		return res.status(500).json({
+			error: 'An unexpected error occurred while deleting constituency',
+		});
+	}
+}
+
+export { fetchConstituencies, addConstituency, updateConstituency, deleteConstituency };
+
+/**
+ * @import { Request, Response } from 'express';
+ */

--- a/controllers/nominationDistricts.js
+++ b/controllers/nominationDistricts.js
@@ -1,0 +1,153 @@
+import handleQuery from '../utils/handleQuery.js';
+import validationError, { checkIdsAndGiveErrors } from '../utils/validationError.js';
+import { validateSingleObjectId } from '../utils/validationError.js';
+import NominationDistrict from '../schemas/NominationDistrict.js';
+
+/**
+ * Fetch nomination districts from the database
+ * @param {Request} req Express request object possibly containing query parameters (e.g. name, constituency)
+ * @param {Response} res Express response object to send the response
+ * @returns {Response} A list of nomination districts or an error message
+ */
+async function fetchNominationDistricts(req, res) {
+	try {
+		const query = handleQuery(req.query, NominationDistrict);
+		const nominationDistricts = await NominationDistrict.find(query);
+		return res.status(200).json(nominationDistricts);
+	} catch (error) {
+		if (error.message.includes('Invalid query parameter')) {
+			return res.status(400).json({
+				error: error.message,
+			});
+		}
+		
+		if (error.name === 'CastError') {
+			return res.status(400).json({
+				error: 'Invalid ID: ' + error.value,
+			});
+		}
+
+		// eslint-disable-next-line no-console
+		console.error(`Error fetching nomination districts: ${error.message}`);
+		return res.status(500).json({
+			error: 'An unexpected error occurred while fetching nomination districts',
+		});
+	}
+}
+
+/**
+ * Create a new nomination district and save it to the database
+ * @param {Request} req Express request object containing the nomination district object in the body
+ * @param {Response} res Express response object to send the response
+ * @returns {Response} Success or error message with the new nomination district (if successful)
+ */
+async function addNominationDistrict(req, res) {
+	const nominationDistrict = req.body;
+	const newNominationDistrict = new NominationDistrict(nominationDistrict);
+
+	try {
+		await newNominationDistrict.save();
+		return res.status(201).json({
+			message: 'Nomination district added successfully',
+			nominationDistrict: newNominationDistrict,
+		});
+	} catch (error) {
+		if (error.name === 'ValidationError') {
+			return res.status(400).json({
+				errors: validationError(error),
+			});
+		}
+		// eslint-disable-next-line no-console
+		console.error(`Error adding nomination district: ${error.message}`);
+		return res.status(500).json({
+			error: 'An unexpected error occurred while adding nomination district',
+		});
+	}
+}
+
+/**
+ * Update a nomination district in the database
+ * @param {Request} req Express request object containing the nomination district object in the body and the nomination district ID in the params
+ * @param {Response} res Express response object to send the response
+ * @returns {Response} Success or error message with the updated nomination district (if successful)
+ */
+async function updateNominationDistrict(req, res) {
+	const id = req.params.id;
+	const { constituency } = req.body;
+
+	if (!validateSingleObjectId(id)) {
+		return res.status(400).json({
+			error: 'Invalid ID: ' + id,
+		});
+	}
+	
+	const idErrs = checkIdsAndGiveErrors([{ name: 'constituency', id: constituency }]);
+	if (Object.keys(idErrs).length > 0) {
+    return res.status(400).json({
+      errors: idErrs,
+    });
+  }
+
+	const nominationDistrict = req.body;
+	try {
+		const updatedNominationDistrict = await NominationDistrict.findByIdAndUpdate(id, nominationDistrict, { new: true, runValidators: true });
+		if (!updatedNominationDistrict) {
+			return res.status(404).json({
+				error: 'Nomination district not found',
+			});
+		}
+		return res.status(200).json({
+			message: 'Nomination district updated successfully',
+			nominationDistrict: updatedNominationDistrict,
+		});
+	} catch (error) {
+		if (error.name === 'ValidationError') {
+			return res.status(400).json({
+				errors: validationError(error),
+			});
+		}
+		// eslint-disable-next-line no-console
+		console.error(`Error updating nomination district: ${error.message}`);
+		return res.status(500).json({
+			error: 'An unexpected error occurred while updating nomination district',
+		});
+	}
+}
+
+/**
+ * Delete a nomination district from the database
+ * @param {Request} req Express request object containing the nomination district ID in the params
+ * @param {Response} res Express response object to send the response
+ * @returns {Response} Success or error message with the deleted nomination district (if found)
+ */
+async function deleteNominationDistrict(req, res) {
+	const id = req.params.id;
+	if (!validateSingleObjectId(id)) {
+		return res.status(400).json({
+			error: 'Invalid ID: ' + id,
+		});
+	}
+
+	try {
+		const deletedNominationDistrict = await NominationDistrict.findByIdAndDelete(id);
+		if (!deletedNominationDistrict) {
+			return res.status(204).send();
+		}
+		return res.status(200).json({
+			message: 'Nomination district deleted successfully',
+			nominationDistrict: deletedNominationDistrict,
+		});
+	} catch (error) {
+		// eslint-disable-next-line no-console
+		console.error(`Error deleting nomination district: ${error.message}`);
+		return res.status(500).json({
+			error: 'An unexpected error occurred while deleting nomination district',
+		});
+	}
+}
+
+export { fetchNominationDistricts, addNominationDistrict, updateNominationDistrict, deleteNominationDistrict };
+
+/**
+ * @import { Request, Response } from 'express';
+ */

--- a/controllers/party.js
+++ b/controllers/party.js
@@ -1,6 +1,39 @@
 import Party from '../schemas/Party.js';
+import handleQuery from '../utils/handleQuery.js';
 import validationError from '../utils/validationError.js';
 import { validateSingleObjectId } from '../utils/validationError.js';
+
+/**
+ * Fetch parties from the database
+ * @param {Request} req Express request object possibly containing query parameters (e.g. name, _id)
+ * @param {Response} res Express response object to send the response
+ * @returns {Response} A list of parties or an error message
+ */
+async function fetchParties(req, res) {
+	try {
+    const query = handleQuery(req.query, Party);
+    const parties = await Party.find(query);
+    return res.status(200).json(parties);
+  } catch (error) {
+    if (error.message.includes('Invalid query parameter')) {
+      return res.status(400).json({
+        error: error.message,
+      });
+    }
+    
+    if (error.name === 'CastError') {
+      return res.status(400).json({
+        error: 'Invalid ID: ' + error.value,
+      });
+    }
+
+    // eslint-disable-next-line no-console
+    console.error(`Error fetching parties: ${error.message}`);
+    return res.status(500).json({
+      error: 'An unexpected error occurred while fetching parties',
+    });
+  }
+}
 
 /**
  * Add a party to the database
@@ -145,7 +178,7 @@ function validateUpdateRequest(partyId, updatedPartyData) {
 	return null;
 }
 
-export { addParty, updateParty, deleteParty };
+export { fetchParties, addParty, updateParty, deleteParty };
 
 /**
  * @import { Request, Response } from 'express';

--- a/controllers/pollingStation.js
+++ b/controllers/pollingStation.js
@@ -1,0 +1,151 @@
+import PollingStation from '../schemas/PollingStation.js';
+import handleQuery from '../utils/handleQuery.js';
+import validationError, { checkIdsAndGiveErrors } from '../utils/validationError.js';
+import { validateSingleObjectId } from '../utils/validationError.js';
+
+/**
+ * Fetch polling stations from the database
+ * @param {Request} req Express request object possibly containing query parameters (e.g. name, _id)
+ * @param {Response} res Express response object to send the response
+ * @returns {Response} A list of polling stations or an error message
+ */
+async function fetchPollingStations(req, res) {
+
+	try {
+		const query = handleQuery(req.query, PollingStation);
+		const pollingStations = await PollingStation.find(query);
+		
+		return res.status(200).json(pollingStations);
+	} catch (error) {
+		if (error.message.includes('Invalid query parameter')) {
+			return res.status(400).json({
+				error: error.message,
+			});
+		}
+		
+		if (error.name === 'CastError') {
+			return res.status(400).json({
+				error: 'Invalid ID: ' + error.value,
+			});
+		}
+
+		// eslint-disable-next-line no-console
+		console.error(`Error fetching polling stations: ${error.message}`);
+		return res.status(500).json({
+			error: 'An unexpected error occurred while fetching polling stations',
+		});
+	}
+}
+
+/**
+ * Add a polling station to the database
+ * @param {Request} req Request object containing the polling station object in the body
+ * @param {Response} res Express response object to send the response
+ * @returns {Response} Success or error message with the added polling station (if valid)
+ */
+async function addPollingStation(req, res) {
+	const pollingStation = req.body;
+	const newPollingStation = new PollingStation(pollingStation);
+
+	try {
+		await newPollingStation.save();
+		return res.status(201).json({
+			message: 'Polling station added successfully',
+			pollingStation: newPollingStation,
+		});
+	} catch (error) {
+		if (error.name === 'ValidationError') {
+			return res.status(400).json({
+				errors: validationError(error),
+			});
+		}
+		// eslint-disable-next-line no-console
+		console.error(`Error adding polling station: ${error.message}`);
+		return res.status(500).json({
+			error: 'An unexpected error occurred while adding polling station',
+		});
+	}
+}
+
+/**
+ * Update a polling station in the database
+ * @param {Request} req Request object containing the polling station object in the body and the polling station ID in the params
+ * @param {Response} res Express response object to send the response
+ * @returns {Response} Success or error message with the updated polling station (if valid)
+ */
+async function updatePollingStation(req, res) {
+	const { id }= req.params;
+	const pollingStation = req.body;
+
+	if (!validateSingleObjectId(id)) {
+		return res.status(400).json({
+			error: 'Invalid ID: ' + id,
+		});
+	}
+
+	const idErrs = checkIdsAndGiveErrors([{ name: 'nominationDistrict', id: pollingStation.nominationDistrict }]);
+
+	if (Object.keys(idErrs).length > 0) {
+		return res.status(400).json({
+			errors: idErrs,
+		});
+	}
+
+	try {
+		const updatedPollingStation = await PollingStation.findByIdAndUpdate(id, pollingStation, { new: true, runValidators: true });
+		if (!updatedPollingStation) {
+			return res.status(404).json({
+				error: 'Polling station not found',
+			});
+		}
+		return res.status(200).json({
+			message: 'Polling station updated successfully',
+			pollingStation: updatedPollingStation,
+		});
+	} catch (error) {
+		if (error.name === 'ValidationError') {
+			return res.status(400).json({
+				errors: validationError(error),
+			});
+		}
+		// eslint-disable-next-line no-console
+		console.error(`Error updating polling station: ${error.message}`);
+		return res.status(500).json({
+			error: 'An unexpected error occurred while updating polling station',
+		});
+	}
+}
+
+/**
+ * Delete a polling station from the database
+ * @param {Request} req Request object containing the polling station ID in the params
+ * @param {Response} res Express response object to send the response
+ * @returns {Response} Success or error message with the deleted polling station (if found)
+ */
+async function deletePollingStation(req, res) {
+	const id = req.params.id;
+	if (!validateSingleObjectId(id)) {
+		return res.status(400).json({
+			error: 'Invalid ID: ' + id,
+		});
+	}
+
+	try {
+		const deletedPollingStation = await PollingStation.findByIdAndDelete(id);
+		if (!deletedPollingStation) {
+			return res.status(204).send();
+		}
+		return res.status(200).json({
+			message: 'Polling station deleted successfully',
+			pollingStation: deletedPollingStation,
+		});
+	} catch (error) {
+		// eslint-disable-next-line no-console
+		console.error(`Error deleting polling station: ${error.message}`);
+		return res.status(500).json({
+			error: 'An unexpected error occurred while deleting polling station',
+		});
+	}
+}
+
+export { fetchPollingStations, addPollingStation, updatePollingStation, deletePollingStation };

--- a/keyGen.js
+++ b/keyGen.js
@@ -16,7 +16,7 @@ function generateKey() {
     },
     key,
     {
-      expiresIn: '24h'
+      expiresIn: '2h'
     }
   );
   return token;

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
             "/node_modules/",
             "/__test__/",
             "/models/",
-            "/config/"
+            "/config/",
+            "/schemas/"
         ],
         "globalSetup": "<rootDir>/__test__/setup/jest-setup.js",
         "globalTeardown": "<rootDir>/__test__/setup/jest-teardown.js",

--- a/routes/candidateRoutes.js
+++ b/routes/candidateRoutes.js
@@ -1,9 +1,12 @@
 import express from 'express';
-import { addCandidate, updateCandidate, deleteCandidate } from '../controllers/candidate.js';
+import { fetchCandidates, addCandidate, updateCandidate, deleteCandidate } from '../controllers/candidate.js';
 import { auth } from '../middleware/verifyToken.js';
 
 const router = express.Router();
 
+router.get('/', auth, (req, res) => {
+  fetchCandidates(req, res);
+});
 // Route for adding a candidate to the database
 router.post('/', auth, (req, res) => {
   addCandidate(req, res);

--- a/routes/constituencyRoutes.js
+++ b/routes/constituencyRoutes.js
@@ -1,0 +1,27 @@
+import express from 'express';
+import { auth } from '../middleware/verifyToken.js';
+import { fetchConstituencies, addConstituency, updateConstituency, deleteConstituency } from '../controllers/constituency.js';
+
+const router = express.Router();
+
+// Route for fetching constituencies from the database
+router.get('/', auth, (req, res) => {
+	fetchConstituencies(req, res);
+});
+
+// Route for adding a constituency to the database
+router.post('/', auth, (req, res) => {
+	addConstituency(req, res);
+});
+
+// Route for editing a constituency in the database
+router.patch('/:id', auth, (req, res) => {
+	updateConstituency(req, res);
+});
+
+// Route for deleting a constituency from the database
+router.delete('/:id', auth, (req, res) => {
+	deleteConstituency(req, res);
+});
+
+export default router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,6 +3,8 @@ import electionRoutes from './electionRoutes.js';
 import candidateRoutes from './candidateRoutes.js';
 import partyRoutes from './partyRoutes.js';
 import nominationDistrictRoutes from './nominationDistrictRoutes.js';
+import constituencyRoutes from './constituencyRoutes.js';
+import pollingStationRoutes from './pollingStationRoutes.js';
 
 const router = express.Router();
 
@@ -14,6 +16,8 @@ router.use('/election', electionRoutes);
 router.use('/candidates', candidateRoutes);
 router.use('/parties', partyRoutes);
 router.use('/nominationDistricts', nominationDistrictRoutes);
+router.use('/constituencies', constituencyRoutes);
+router.use('/pollingStations', pollingStationRoutes);
 
 
 export default router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,6 +2,7 @@ import express from 'express';
 import electionRoutes from './electionRoutes.js';
 import candidateRoutes from './candidateRoutes.js';
 import partyRoutes from './partyRoutes.js';
+import nominationDistrictRoutes from './nominationDistrictRoutes.js';
 
 const router = express.Router();
 
@@ -12,6 +13,7 @@ router.get('/', (req, res) => {
 router.use('/election', electionRoutes);
 router.use('/candidates', candidateRoutes);
 router.use('/parties', partyRoutes);
+router.use('/nominationDistricts', nominationDistrictRoutes);
 
 
 export default router;

--- a/routes/nominationDistrictRoutes.js
+++ b/routes/nominationDistrictRoutes.js
@@ -1,0 +1,27 @@
+import express from 'express';
+import { auth } from '../middleware/verifyToken.js';
+import { addNominationDistrict, deleteNominationDistrict, fetchNominationDistricts, updateNominationDistrict } from '../controllers/nominationDistricts.js';
+
+const router = express.Router();
+
+// Route for fetching nomination districts from the database
+router.get('/', auth, (req, res) => {
+	fetchNominationDistricts(req, res);
+});
+
+// Route for adding a nomination district to the database
+router.post('/', auth, (req, res) => {
+	addNominationDistrict(req, res);
+});
+
+// Route for editing a nomination district in the database
+router.patch('/:id', auth, (req, res) => {
+	updateNominationDistrict(req, res);
+});
+
+// Route for deleting a nomination district from the database
+router.delete('/:id', auth, (req, res) => {
+	deleteNominationDistrict(req, res);
+});
+
+export default router;

--- a/routes/partyRoutes.js
+++ b/routes/partyRoutes.js
@@ -1,8 +1,13 @@
 import express from 'express';
-import { addParty, updateParty, deleteParty } from '../controllers/party.js';
+import { fetchParties, addParty, updateParty, deleteParty } from '../controllers/party.js';
 import { auth } from '../middleware/verifyToken.js';
 
 const router = express.Router();
+
+// Route for fetching parties from the database
+router.get('/', auth, (req, res) => {
+	fetchParties(req, res);
+});
 
 // Route for adding a party to the database
 router.post('/', auth, (req, res) => {

--- a/routes/pollingStationRoutes.js
+++ b/routes/pollingStationRoutes.js
@@ -1,0 +1,27 @@
+import express from 'express';
+import { auth } from '../middleware/verifyToken.js';
+import { fetchPollingStations, addPollingStation, updatePollingStation, deletePollingStation } from '../controllers/pollingStation.js';
+
+const router = express.Router();
+
+// Route for fetching polling stations from the database
+router.get('/', auth, (req, res) => {
+	fetchPollingStations(req, res);
+});
+
+// Route for adding a polling station to the database
+router.post('/', auth, (req, res) => {
+	addPollingStation(req, res);
+});
+
+// Route for editing a polling station in the database
+router.patch('/:id', auth, (req, res) => {
+	updatePollingStation(req, res);
+});
+
+// Route for deleting a polling station from the database
+router.delete('/:id', auth, (req, res) => {
+	deletePollingStation(req, res);
+});
+
+export default router;

--- a/utils/handleQuery.js
+++ b/utils/handleQuery.js
@@ -1,0 +1,43 @@
+// Sanitize query string and return an object for Sequelize query
+
+import { Schema } from 'mongoose';
+
+/**
+ * Sanitize query string and return an object for mongoose query
+ * @param {object} query user query object to sanitize and check for valid query parameters
+ * @param {Schema} model mongoose schema to check for valid query
+ * @returns {object} sanitized query object with valid query parameters
+ */
+const handleQuery = (query, model) => {
+	let queryObj = {};
+
+	for (const key in query) {
+		if (model.schema.paths[key]) {
+			if (typeof query[key] === 'string') {
+				queryObj[key] = sanitize(query[key].split(','));
+			} else {
+				queryObj[key] = sanitize(query[key]);
+			}
+		} else if (key === 'populate' && query[key]) {
+			queryObj.populate = query[key];
+		} else {
+			throw Error(`Invalid query parameter: ${key}`);
+		}
+	}
+
+	return queryObj;
+};
+
+/**
+ * Sanitize input to remove special characters and return only alphanumeric characters and spaces
+ * @param {*} input unsanitized input
+ * @returns {*} sanitized input
+ */
+const sanitize = (input) => {
+	if (Array.isArray(input) && typeof input[0] === 'string')
+		return input.map(str => str.replace(/[^a-zA-Z0-9 ]/g, ''));
+
+	return input;
+};
+
+export default handleQuery;


### PR DESCRIPTION
## Description

CRUD functionality (GET, POST, PATCH, and DELETE endpoints) for all relevant objects.

## Changes made
- added handleQuery to check queries for GET reqs
- GET endpoint for parties
- GET endpoint for candidates
- CRUD endpoints for nomination districts 
- clearing of db before tests
- added polling stations to testPopulation
- CRUD for polling stations
- CRUD for constituencies