### PR TITLE
feat: endpoint for getting number of keys

### DIFF
--- a/__test__/routes/keyRoutes.test.js
+++ b/__test__/routes/keyRoutes.test.js
@@ -141,7 +141,7 @@ describe('GET /api/v1/keys/', () => {
 		expect(response.body).toEqual({
 			totalKeys: 18,
 		});
-	})
+	});
 
 	it('should return 500 Internal Server Error when an unexpected error occurs', async () => {
 		await testInternalServerError('get', `${baseRoute}/`, () => {

--- a/__test__/routes/keyRoutes.test.js
+++ b/__test__/routes/keyRoutes.test.js
@@ -2,9 +2,10 @@ import request from 'supertest';
 import express from 'express';
 import mongoose from 'mongoose';
 import connectDb from '../setup/connect.js';
-import { jest } from '@jest/globals';
+import { describe, jest } from '@jest/globals';
 import populateDb from '../db/testPopulation.js';
 import PollingStation from '../../schemas/PollingStation.js';
+import Key from '../../schemas/Key.js';
 import axios from 'axios';
 
 let router;
@@ -48,6 +49,19 @@ jest.unstable_mockModule('bull', () => {
 		default: mockQueue,
 	};
 });
+
+const testInternalServerError = async (method, url, mockFunction, expectedMessage) => {
+	mockFunction();
+	jest.spyOn(console, 'error').mockImplementation(() => { });
+
+	const response = await request(app)[method](url);
+
+	expect(response.statusCode).toBe(500);
+	expect(response.body).toEqual({
+		status: 'error',
+		error: expectedMessage,
+	});
+};
 
 describe('GET /api/v1/keys/generate', () => {
 	jest.spyOn(axios, 'get').mockResolvedValue({ data: { currentPhase: '0' } });
@@ -112,16 +126,27 @@ describe('GET /api/v1/keys/generate', () => {
 	});
 
 	it('should return 500 Internal Server Error when an unexpected error occurs', async () => {
-		jest.spyOn(axios, 'get').mockRejectedValue(new Error('Unexpected error'));
-		jest.spyOn(console, 'error').mockImplementation(() => { });
+		await testInternalServerError('post', `${baseRoute}/generate`, () => {
+			jest.spyOn(axios, 'get').mockRejectedValue(new Error('Unexpected error'));
+		}, 'An unexpected error occurred while checking the current phase');
+	});
+});
 
-		const response = await request(app).post(`${baseRoute}/generate`);
+describe('GET /api/v1/keys/', () => {
+	it('should return the total number of keys', async () => {
+		Key.insertMany([...Array(18)].map(() => ({ pollingStation: new mongoose.Types.ObjectId(), keyHash: 'hash' })));
+		const response = await request(app).get(`${baseRoute}/`);
 
-		expect(response.statusCode).toBe(500);
+		expect(response.statusCode).toBe(200);
 		expect(response.body).toEqual({
-			status: 'error',
-			error: 'An unexpected error occurred while checking the current phase',
+			totalKeys: 18,
 		});
+	})
+
+	it('should return 500 Internal Server Error when an unexpected error occurs', async () => {
+		await testInternalServerError('get', `${baseRoute}/`, () => {
+			jest.spyOn(Key, 'countDocuments').mockRejectedValue(new Error('Unexpected error occurred'));
+		}, 'An unexpected error occurred while fetching the total number of keys');
 	});
 });
 
@@ -142,6 +167,8 @@ describe('GET /api/v1/keys/status/:queueId', () => {
 });
 
 afterAll(async () => {
+	await PollingStation.deleteMany({});
+	await Key.deleteMany({});
 	await mongoose.connection.close();
 	server.close();
 });

--- a/routes/keyRoutes.js
+++ b/routes/keyRoutes.js
@@ -1,11 +1,15 @@
 import express from 'express';
 import { auth } from '../middleware/verifyToken.js';
-import { generateKeys } from '../controllers/keys.js';
+import { generateKeys, getTotalKeys } from '../controllers/keys.js';
 
 // Queue status
 import Queue from 'bull';
 
 const router = express.Router();
+
+router.get('/', (req, res) => {
+	getTotalKeys(req, res);
+});
 
 router.post('/generate', auth, (req, res) => {
 	generateKeys(req, res);


### PR DESCRIPTION
## Description
This pull request includes several changes to the `keyRoutes` and `keys` controller to add new functionality and improve error handling. The most important changes include adding a new route to get the total number of keys, refactoring error handling in tests, and cleaning up the database after tests.

## Changes made
### New functionality:

* [`routes/keyRoutes.js`](diffhunk://#diff-19718b6e16a5d447994e23e50b94e412b452a30b60c528c827d22ebc14af2c1fL3-R13): Added a new GET route to fetch the total number of keys from the database by calling the `getTotalKeys` function from the `keys` controller.
* [`controllers/keys.js`](diffhunk://#diff-694f958cad62b896a13010bef880305efc3c5e3023981e9fc17f8799f9d86f9eR6-R32): Implemented the `getTotalKeys` function to count and return the total number of keys in the database.

### Error handling improvements:

* [`__test__/routes/keyRoutes.test.js`](diffhunk://#diff-c69f72495427602a2160cf7c038310a9446f55f0a85f3ae3100e4b9d4ae0d9f8R53-R65): Added a helper function `testInternalServerError` to standardize the testing of internal server errors across different routes.
* [`__test__/routes/keyRoutes.test.js`](diffhunk://#diff-c69f72495427602a2160cf7c038310a9446f55f0a85f3ae3100e4b9d4ae0d9f8R129-R149): Refactored existing tests to use the `testInternalServerError` function for handling unexpected errors in the `GET /api/v1/keys/generate` and `GET /api/v1/keys/` routes.

### Database cleanup:

* [`__test__/routes/keyRoutes.test.js`](diffhunk://#diff-c69f72495427602a2160cf7c038310a9446f55f0a85f3ae3100e4b9d4ae0d9f8R170-R171): Added cleanup steps to delete all documents from the `PollingStation` and `Key` collections after running the tests.