### PR TITLE
feat: switch to paillier-bigint

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "schemas"]
 	path = schemas
 	url = https://github.com/SW7-Decentralized-voting/shared-schema.git
+	branch = new-keypair

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "schemas"]
 	path = schemas
 	url = https://github.com/SW7-Decentralized-voting/shared-schema.git
-	branch = new-keypair

--- a/__test__/routes/electionRoutes.test.js
+++ b/__test__/routes/electionRoutes.test.js
@@ -61,10 +61,15 @@ describe('POST /api/v1/elections/start', () => {
 		await request(app).post(`${baseRoute}/start`);
 		const keyPair = await KeyPair.findOne();
 		const pubKey = keyPair.publicKey;
-		const privKey = keyPair.privateKey;
+		const privKey = keyPair;
 
-		expect(pubKey).toEqual(expect.stringMatching(/-----BEGIN PUBLIC KEY-----(.|\n)+-----END PUBLIC KEY-----\n/));
-		expect(privKey).toEqual(expect.stringMatching(/-----BEGIN PRIVATE KEY-----(.|\n)+-----END PRIVATE KEY-----\n/));
+		// console.log(keyPair);
+
+		// Ensure that private key has string lambda, mu and publicKey has string n, g
+		expect(typeof privKey.lambda).toBe('string');
+		expect(typeof privKey.mu).toBe('string');
+		expect(typeof pubKey.n).toBe('string');
+		expect(typeof pubKey.g).toBe('string');
 
 		await KeyPair.deleteMany();
 	});

--- a/__test__/routes/electionRoutes.test.js
+++ b/__test__/routes/electionRoutes.test.js
@@ -30,16 +30,16 @@ jest.unstable_mockModule('../../middleware/verifyToken.js', () => {
 });
 
 describe('POST /api/v1/elections/start', () => {
-	 const testStartElection = async (expectedStatus, mockResponse, expectedMessage) => {
+	const testStartElection = async (expectedStatus, mockResponse, expectedMessage) => {
 		const spy = jest.spyOn(axios, 'post').mockImplementation(() => {
 			if (expectedStatus === 200) {
 				return Promise.resolve(mockResponse);
 			}
 			return Promise.reject(mockResponse);
 		});
-		
+
 		const response = await request(app).post(`${baseRoute}/start`);
-	
+
 		expect(response.statusCode).toBe(expectedStatus);
 		if (expectedStatus === 200) {
 			expect(response.body.message).toBe(expectedMessage);
@@ -63,9 +63,6 @@ describe('POST /api/v1/elections/start', () => {
 		const pubKey = keyPair.publicKey;
 		const privKey = keyPair;
 
-		// console.log(keyPair);
-
-		// Ensure that private key has string lambda, mu and publicKey has string n, g
 		expect(typeof privKey.lambda).toBe('string');
 		expect(typeof privKey.mu).toBe('string');
 		expect(typeof pubKey.n).toBe('string');
@@ -79,7 +76,7 @@ describe('POST /api/v1/elections/start', () => {
 	});
 
 	it('should return 500 Internal Server Error when blockchain service is unreachable', async () => {
-		jest.spyOn(axios, 'post').mockRejectedValue({ });
+		jest.spyOn(axios, 'post').mockRejectedValue({});
 		const response = await request(app).post(`${baseRoute}/start`);
 		expect(response.statusCode).toBe(500);
 		expect(response.body.error).toBe('Blockchain service cannot be reached');
@@ -117,7 +114,7 @@ describe('POST /api/v1/elections/advance-phase', () => {
 	});
 
 	it('should return 500 Internal Server Error when blockchain service is unreachable', async () => {
-		jest.spyOn(axios, 'post').mockRejectedValue({ });
+		jest.spyOn(axios, 'post').mockRejectedValue({});
 		const response = await request(app).post(`${baseRoute}/advance-phase`);
 		expect(response.statusCode).toBe(500);
 		expect(response.body.error).toBe('Blockchain service cannot be reached');
@@ -168,7 +165,7 @@ describe('GET /api/v1/elections/phase', () => {
 	});
 
 	it('should return 500 Internal Server Error when blockchain service is unreachable', async () => {
-		jest.spyOn(axios, 'get').mockRejectedValue({ });
+		jest.spyOn(axios, 'get').mockRejectedValue({});
 		const response = await request(app).get(`${baseRoute}/phase`);
 		expect(response.statusCode).toBe(500);
 		expect(response.body.error).toBe('Blockchain service cannot be reached');

--- a/__test__/utils/encryptionKeys.test.js
+++ b/__test__/utils/encryptionKeys.test.js
@@ -1,31 +1,19 @@
 import { getKeyPair } from '../../utils/encryptionKeys';
-import { expect, it, jest } from '@jest/globals';
+import { expect, it } from '@jest/globals';
+import * as paillierBigint from 'paillier-bigint';
 
 describe('getKeyPair', () => {
 	it('should return an object with a publicKey and privateKey property', async () => {
-		const result = await getKeyPair();
-		expect(result).toEqual({
-			publicKey: expect.stringMatching(/-----BEGIN PUBLIC KEY-----(.|\n)+-----END PUBLIC KEY-----\n/),
-			privateKey: expect.stringMatching(/-----BEGIN PRIVATE KEY-----(.|\n)+-----END PRIVATE KEY-----\n/)
-		});
+		const { publicKey, privateKey } = await getKeyPair();
+		// Expect to be instance of paillierBigint.PublicKey and paillierBigint.PrivateKey
+		expect(publicKey).toBeInstanceOf(paillierBigint.PublicKey);
+		expect(privateKey).toBeInstanceOf(paillierBigint.PrivateKey);
+
 	});
 
 	it('should return a different key pair each time it is called', async () => {
 		const keyPair1 = await getKeyPair();
 		const keyPair2 = await getKeyPair();
 		expect(keyPair1).not.toEqual(keyPair2);
-	});
-
-	it('should reject with an error if the key pair cannot be generated', async () => {
-		jest.resetModules();
-		jest.unstable_mockModule('crypto', () => ({
-			generateKeyPair: jest.fn((_, __, callback) => {
-				callback(new Error('Key generation failed'));
-			})
-		}));
-		const { getKeyPair } = await import('../../utils/encryptionKeys');
-		await expect(getKeyPair()).rejects.toThrow();
-
-		jest.resetModules();
 	});
 });

--- a/controllers/election.js
+++ b/controllers/election.js
@@ -15,12 +15,26 @@ const url = process.env.BLOCKCHAIN_URL + '/election';
  * @returns {e.Response} Success or error message
  */
 async function startElection(res) {
-  let candidates, parties, keyPair;
+  let candidates, parties, publicKey, privateKey, publicKeyString;
   try {
     candidates = await getAllCandidates();
     parties = await getAllParties();
-    keyPair = await getKeyPair();
-    KeyPair({ publicKey: keyPair.publicKey, privateKey: keyPair.privateKey }).save();
+    ({ publicKey, privateKey } = await getKeyPair());
+
+    KeyPair({
+      lambda: privateKey.lambda.toString(),
+      mu: privateKey.mu.toString(),
+      publicKey: {
+        n: publicKey.n.toString(),
+        g: publicKey.g.toString()
+      }
+    }).save();
+
+    publicKeyString = JSON.stringify({
+      n: publicKey.n.toString(),
+      g: publicKey.g.toString()
+    });
+
   } catch (error) {
     return res.status(500).json({ error: error.message });
   }
@@ -29,7 +43,7 @@ async function startElection(res) {
     // Add body with all candidates and parties
     candidates: candidates,
     parties: parties,
-    publicKey: keyPair.publicKey
+    publicKey: publicKeyString
   })
     .then(response => {
       return res.status(200).json(response.data);

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
                 "mongodb-memory-server": "^10.1.2",
                 "mongoose": "^8.7.2",
                 "nodemon": "^3.1.7",
+                "paillier-bigint": "^3.4.3",
                 "uuid": "^11.0.2"
             },
             "devDependencies": {
@@ -2200,6 +2201,15 @@
             "integrity": "sha512-/E8dDe9dsbLyh2qrZ64PEPadOQ0F4gbl1sUJOrmph7xOiIxfY8vwab/4bFLh4Y88/Hk/ujKcrQKc+ps0mv873A==",
             "license": "Apache-2.0",
             "optional": true
+        },
+        "node_modules/bigint-crypto-utils": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.3.0.tgz",
+            "integrity": "sha512-jOTSb+drvEDxEq6OuUybOAv/xxoh3cuYRUIPyu8sSHQNKM303UQ2R1DAo45o1AkcIXw6fzbaFI1+xGGdaXs2lg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
         },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
@@ -6570,6 +6580,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/paillier-bigint": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/paillier-bigint/-/paillier-bigint-3.4.3.tgz",
+            "integrity": "sha512-82otV7H/gBiQeYjsmc/Zo029GoJDnAFyoMWQMsUgfya50W8dYRVgvUR/lHO0yrS7MfMwgE8fCeEIBF0IucLYFw==",
+            "license": "MIT",
+            "dependencies": {
+                "bigint-crypto-utils": "^3.3.0"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/parent-module": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "mongodb-memory-server": "^10.1.2",
         "mongoose": "^8.7.2",
         "nodemon": "^3.1.7",
+        "paillier-bigint": "^3.4.3",
         "uuid": "^11.0.2"
     },
     "devDependencies": {

--- a/utils/encryptionKeys.js
+++ b/utils/encryptionKeys.js
@@ -1,29 +1,11 @@
-import { generateKeyPair } from 'crypto';
+import * as paillierBigint from 'paillier-bigint';
 
 /**
  * 
- * @returns {Promise<{publicKey: string, privateKey: string}>} Public and private key pair
+ * @returns {Object} A key pair for the Paillier cryptosystem
  */
-function getKeyPair() {
-	return new Promise((resolve, reject) => {
-		generateKeyPair('rsa', {
-			modulusLength: 2048,  // Length of the key in bits
-			publicKeyEncoding: {
-				type: 'spki',       // Recommended to be 'spki' by the Node.js docs
-				format: 'pem'       // Format of the key
-			},
-			privateKeyEncoding: {
-				type: 'pkcs8',      // Recommended to be 'pkcs8' by the Node.js docs
-				format: 'pem'       // Format of the key
-			}
-		}, (err, publicKey, privateKey) => {
-			if (err) {
-				reject(err);
-			} else {
-				resolve({ publicKey, privateKey });
-			}
-		});
-	});
+async function getKeyPair() {
+	return paillierBigint.generateRandomKeys(2048);
 }
 
 export { getKeyPair };

--- a/utils/encryptionKeys.js
+++ b/utils/encryptionKeys.js
@@ -2,7 +2,7 @@ import * as paillierBigint from 'paillier-bigint';
 
 /**
  * 
- * @returns {object} A key pair for the Paillier cryptosystem
+ * @returns {Promise<paillierBigint.KeyPair>} A promise that resolves to a key pair
  */
 async function getKeyPair() {
 	return paillierBigint.generateRandomKeys(2048);

--- a/utils/encryptionKeys.js
+++ b/utils/encryptionKeys.js
@@ -2,7 +2,7 @@ import * as paillierBigint from 'paillier-bigint';
 
 /**
  * 
- * @returns {Object} A key pair for the Paillier cryptosystem
+ * @returns {object} A key pair for the Paillier cryptosystem
  */
 async function getKeyPair() {
 	return paillierBigint.generateRandomKeys(2048);


### PR DESCRIPTION
This pull request includes several changes to update the encryption mechanism to use the Paillier cryptosystem and refactor related code. The most important changes include modifying test cases, updating the key generation function, and adjusting the election start process to accommodate the new encryption keys.

### Encryption Mechanism Update:

* [`__test__/routes/electionRoutes.test.js`](diffhunk://#diff-05a1ba804845fa17a3c43ac32dc68fe79af14f61532cfb1572694c610d8cfc1bL64-R69): Changed the test to verify the structure of the new key pair properties (`lambda`, `mu`, `n`, and `g`) instead of matching PEM strings.
* [`__test__/utils/encryptionKeys.test.js`](diffhunk://#diff-b79f7b342d27203ecfaeb14ab593d251ef122a9bbc8bc654b27658d5062edb11L2-L30): Updated the test to check that the returned keys are instances of `paillierBigint.PublicKey` and `paillierBigint.PrivateKey`. Removed the test case for key generation failure.
* [`utils/encryptionKeys.js`](diffhunk://#diff-fff7625df4c4452c6021715c1608d8453b4671e9f1fa997d3aa2ab06f6b77a00L1-R8): Replaced the RSA key generation with Paillier key generation using the `paillier-bigint` library.

### Election Start Process Adjustment:

* [`controllers/election.js`](diffhunk://#diff-bd3d0088bdc5e18fc4a47740bbac6fbdc2aae27771962007725dade8c20ac239L18-R37): Refactored the `startElection` function to store and use the new key properties (`lambda`, `mu`, `n`, and `g`) and updated the public key format in the response. [[1]](diffhunk://#diff-bd3d0088bdc5e18fc4a47740bbac6fbdc2aae27771962007725dade8c20ac239L18-R37) [[2]](diffhunk://#diff-bd3d0088bdc5e18fc4a47740bbac6fbdc2aae27771962007725dade8c20ac239L32-R46)

### Dependency Update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R38): Added the `paillier-bigint` library as a dependency.